### PR TITLE
Save metrics about the validator's vote account

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5632,6 +5632,7 @@ dependencies = [
  "solana-gossip",
  "solana-runtime",
  "solana-sdk 1.10.27",
+ "solana-vote-program",
 ]
 
 [[package]]

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -173,7 +173,7 @@ pub struct ValidatorConfig {
     pub wait_to_vote_slot: Option<Slot>,
     pub ledger_column_options: LedgerColumnOptions,
     pub enable_quic_servers: bool,
-    pub observable_vote_acounts: Arc<HashSet<Pubkey>>,
+    pub vote_accounts_to_monitor: Arc<HashSet<Pubkey>>,
 }
 
 impl Default for ValidatorConfig {
@@ -238,7 +238,7 @@ impl Default for ValidatorConfig {
             wait_to_vote_slot: None,
             ledger_column_options: LedgerColumnOptions::default(),
             enable_quic_servers: false,
-            observable_vote_acounts: Arc::new(HashSet::new()),
+            vote_accounts_to_monitor: Arc::new(HashSet::new()),
         }
     }
 }
@@ -730,7 +730,7 @@ impl Validator {
                     leader_schedule_cache.clone(),
                     connection_cache.clone(),
                     max_complete_transaction_status_slot,
-                    config.observable_vote_acounts.clone(),
+                    config.vote_accounts_to_monitor.clone(),
                 )),
                 if !config.rpc_config.full_api {
                     None

--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -173,6 +173,7 @@ pub struct ValidatorConfig {
     pub wait_to_vote_slot: Option<Slot>,
     pub ledger_column_options: LedgerColumnOptions,
     pub enable_quic_servers: bool,
+    pub observable_vote_acounts: Arc<HashSet<Pubkey>>,
 }
 
 impl Default for ValidatorConfig {
@@ -237,6 +238,7 @@ impl Default for ValidatorConfig {
             wait_to_vote_slot: None,
             ledger_column_options: LedgerColumnOptions::default(),
             enable_quic_servers: false,
+            observable_vote_acounts: Arc::new(HashSet::new()),
         }
     }
 }
@@ -728,6 +730,7 @@ impl Validator {
                     leader_schedule_cache.clone(),
                     connection_cache.clone(),
                     max_complete_transaction_status_slot,
+                    config.observable_vote_acounts.clone(),
                 )),
                 if !config.rpc_config.full_api {
                     None

--- a/prometheus/Cargo.toml
+++ b/prometheus/Cargo.toml
@@ -12,6 +12,7 @@ jsonrpc-http-server = "18.0.0"
 solana-gossip = { path = "../gossip", version = "=1.10.27" }
 solana-runtime = { path = "../runtime", version = "=1.10.27" }
 solana-sdk = { path = "../sdk", version = "=1.10.27" }
+solana-vote-program = { path = "../programs/vote", version = "=1.10.27" }
 
 [lib]
 crate-type = ["lib"]

--- a/prometheus/src/bank_metrics.rs
+++ b/prometheus/src/bank_metrics.rs
@@ -15,8 +15,7 @@ pub fn write_bank_metrics<W: io::Write>(
             help: "Block Slot",
             type_: "gauge",
             metrics: banks_with_commitments
-                .for_each_commitment(|bank| Some(Metric::new(bank.clock().slot)))
-                .unwrap(),
+                .for_each_commitment(|bank| Some(Metric::new(bank.clock().slot))),
         },
     )?;
     write_metric(
@@ -26,8 +25,7 @@ pub fn write_bank_metrics<W: io::Write>(
             help: "Block Epoch",
             type_: "gauge",
             metrics: banks_with_commitments
-                .for_each_commitment(|bank| Some(Metric::new(bank.clock().epoch)))
-                .unwrap(),
+                .for_each_commitment(|bank| Some(Metric::new(bank.clock().epoch))),
         },
     )?;
     write_metric(
@@ -37,8 +35,7 @@ pub fn write_bank_metrics<W: io::Write>(
             help: "The block's UNIX timestamp, in seconds since epoch, UTC",
             type_: "gauge",
             metrics: banks_with_commitments
-                .for_each_commitment(|bank| Some(Metric::new(bank.clock().unix_timestamp as u64)))
-                .unwrap(),
+                .for_each_commitment(|bank| Some(Metric::new(bank.clock().unix_timestamp as u64))),
         },
     )?;
 

--- a/prometheus/src/bank_metrics.rs
+++ b/prometheus/src/bank_metrics.rs
@@ -15,7 +15,8 @@ pub fn write_bank_metrics<W: io::Write>(
             help: "Block Slot",
             type_: "gauge",
             metrics: banks_with_commitments
-                .for_each_commitment(|bank| Metric::new(bank.clock().slot)),
+                .for_each_commitment(|bank| Some(Metric::new(bank.clock().slot)))
+                .unwrap(),
         },
     )?;
     write_metric(
@@ -25,7 +26,8 @@ pub fn write_bank_metrics<W: io::Write>(
             help: "Block Epoch",
             type_: "gauge",
             metrics: banks_with_commitments
-                .for_each_commitment(|bank| Metric::new(bank.clock().epoch)),
+                .for_each_commitment(|bank| Some(Metric::new(bank.clock().epoch)))
+                .unwrap(),
         },
     )?;
     write_metric(
@@ -35,7 +37,8 @@ pub fn write_bank_metrics<W: io::Write>(
             help: "The block's UNIX timestamp, in seconds since epoch, UTC",
             type_: "gauge",
             metrics: banks_with_commitments
-                .for_each_commitment(|bank| Metric::new(bank.clock().unix_timestamp as u64)),
+                .for_each_commitment(|bank| Some(Metric::new(bank.clock().unix_timestamp as u64)))
+                .unwrap(),
         },
     )?;
 

--- a/prometheus/src/banks_with_commitments.rs
+++ b/prometheus/src/banks_with_commitments.rs
@@ -59,14 +59,20 @@ impl BanksWithCommitments {
     }
 
     /// Call function callback for each commitment level, and returns a vector of metrics.
-    pub fn for_each_commitment<F: Fn(&Bank) -> Option<Metric>>(
-        &self,
-        get: F,
-    ) -> Option<Vec<Metric>> {
-        Some(vec![
-            get(&self.finalized_bank)?.with_label("commitment_level", "finalized".to_owned()),
-            get(&self.confirmed_bank)?.with_label("commitment_level", "confirmed".to_owned()),
-            get(&self.processed_bank)?.with_label("commitment_level", "processed".to_owned()),
-        ])
+    pub fn for_each_commitment<F: Fn(&Bank) -> Option<Metric>>(&self, get: F) -> Vec<Metric> {
+        let mut result = Vec::with_capacity(3);
+        result.extend(
+            get(&self.finalized_bank)
+                .map(|m| m.with_label("commitment_level", "finalized".to_owned())),
+        );
+        result.extend(
+            get(&self.confirmed_bank)
+                .map(|m| m.with_label("commitment_level", "confirmed".to_owned())),
+        );
+        result.extend(
+            get(&self.processed_bank)
+                .map(|m| m.with_label("commitment_level", "processed".to_owned())),
+        );
+        result
     }
 }

--- a/prometheus/src/banks_with_commitments.rs
+++ b/prometheus/src/banks_with_commitments.rs
@@ -59,11 +59,14 @@ impl BanksWithCommitments {
     }
 
     /// Call function callback for each commitment level, and returns a vector of metrics.
-    pub fn for_each_commitment<F: Fn(&Bank) -> Metric>(&self, get: F) -> Vec<Metric> {
-        vec![
-            get(&self.finalized_bank).with_label("commitment_level", "finalized".to_owned()),
-            get(&self.confirmed_bank).with_label("commitment_level", "confirmed".to_owned()),
-            get(&self.processed_bank).with_label("commitment_level", "processed".to_owned()),
-        ]
+    pub fn for_each_commitment<F: Fn(&Bank) -> Option<Metric>>(
+        &self,
+        get: F,
+    ) -> Option<Vec<Metric>> {
+        Some(vec![
+            get(&self.finalized_bank)?.with_label("commitment_level", "finalized".to_owned()),
+            get(&self.confirmed_bank)?.with_label("commitment_level", "confirmed".to_owned()),
+            get(&self.processed_bank)?.with_label("commitment_level", "processed".to_owned()),
+        ])
     }
 }

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -29,10 +29,10 @@ impl ValidatorVoteInfo {
                     return None;
                 }
                 let last_vote = if let Some(vote) = vote_state.votes.iter().last() {
-                    vote.slot
+                    Some(vote.slot)
                 } else {
-                    0
-                };
+                    None
+                }?;
                 let vote_balance = Lamports(bank.get_balance(&vote_pubkey));
                 Some(ValidatorVoteInfo {
                     vote_address: vote_pubkey,

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -1,4 +1,7 @@
 use solana_gossip::cluster_info::ClusterInfo;
+use solana_runtime::bank::Bank;
+use solana_sdk::{clock::Slot, pubkey::Pubkey};
+use solana_vote_program::vote_state::VoteState;
 
 use crate::{
     banks_with_commitments::BanksWithCommitments,
@@ -6,6 +9,76 @@ use crate::{
     Lamports,
 };
 use std::{io, sync::Arc};
+
+struct ValidatorVoteInfo {
+    vote_address: Pubkey,
+    balance: Lamports,
+    last_vote: Slot,
+}
+
+impl ValidatorVoteInfo {
+    fn new_from_bank(bank: &Arc<Bank>, identity_pubkey: &Pubkey) -> Option<Self> {
+        let vote_accounts = bank.vote_accounts();
+        let vote_state_default = VoteState::default();
+        vote_accounts
+            .iter()
+            .filter_map(|(&vote_pubkey, (_activated_stake, account))| {
+                let vote_state = account.vote_state();
+                let vote_state = vote_state.as_ref().unwrap_or(&vote_state_default);
+                if identity_pubkey != &vote_state.node_pubkey {
+                    return None;
+                }
+                let last_vote = if let Some(vote) = vote_state.votes.iter().last() {
+                    vote.slot
+                } else {
+                    0
+                };
+                let vote_balance = Lamports(bank.get_balance(&vote_pubkey));
+                Some(ValidatorVoteInfo {
+                    vote_address: vote_pubkey,
+                    balance: vote_balance,
+                    last_vote,
+                })
+            })
+            .next()
+    }
+
+    fn write_prometheus<W: io::Write>(&self, out: &mut W, at: SystemTime) -> io::Result<()> {
+        write_metric(
+            out,
+            &MetricFamily {
+                name: "solana_cluster_vote_public_key_info",
+                help: "The current Solana node's vote public key",
+                type_: "count",
+                metrics: vec![Metric::new(1)
+                    .with_label("vote", self.vote_address.to_string())
+                    .at(at)],
+            },
+        )?;
+        // We can use this metric to track if the validator is making progress
+        // by voting on the last slots.
+        write_metric(
+            out,
+            &MetricFamily {
+                name: "solana_cluster_last_vote_slot_count",
+                help: "The last slot that the validator voted on",
+                type_: "gauge",
+                metrics: vec![Metric::new(self.last_vote).at(at)],
+            },
+        )?;
+        // Validator rewards go to vote account, we use this to track our own
+        // rewards.
+        write_metric(
+            out,
+            &MetricFamily {
+                name: "solana_cluster_vote_balance_total",
+                help: "The current node's vote account balance",
+                type_: "gauge",
+                metrics: vec![Metric::new_sol(self.balance).at(at)],
+            },
+        )
+    }
+}
 
 pub fn write_cluster_metrics<W: io::Write>(
     banks_with_commitments: &BanksWithCommitments,
@@ -51,6 +124,11 @@ pub fn write_cluster_metrics<W: io::Write>(
             metrics: vec![Metric::new(1).with_label("version", version.to_string())],
         },
     )?;
+
+    let validator_vote_info = ValidatorVoteInfo::new_from_bank(bank, &identity_pubkey);
+    if let Some(vote_info) = validator_vote_info {
+        vote_info.write_prometheus(out, at)?;
+    }
 
     Ok(())
 }

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -105,7 +105,7 @@ pub fn write_cluster_metrics<W: io::Write>(
             out,
             &MetricFamily {
                 name: "solana_node_vote_balance_sol",
-                help: "The current node's vote account balance",
+                help: "The balance of the vote account at the given address",
                 type_: "gauge",
                 metrics: banks_with_commitments.for_each_commitment(|bank| {
                     let vote_info = get_vote_state(bank, vote_account)?;
@@ -122,7 +122,7 @@ pub fn write_cluster_metrics<W: io::Write>(
             out,
             &MetricFamily {
                 name: "solana_node_vote_credits",
-                help: "The current node's vote vote credits for current epoch",
+                help: "The total number of vote credits credited to this vote account",
                 type_: "gauge",
                 metrics: banks_with_commitments.for_each_commitment(|bank| {
                     let vote_info = get_vote_state(bank, vote_account)?;

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -86,7 +86,7 @@ pub fn write_cluster_metrics<W: io::Write>(
         write_metric(
             out,
             &MetricFamily {
-                name: "solana_node_last_vote_slot",
+                name: "solana_validator_last_vote_slot",
                 help:
                     "The voted-on slot of the validator's last vote that got included in the chain",
                 type_: "gauge",
@@ -104,7 +104,7 @@ pub fn write_cluster_metrics<W: io::Write>(
         write_metric(
             out,
             &MetricFamily {
-                name: "solana_node_vote_balance_sol",
+                name: "solana_validator_vote_balance_sol",
                 help: "The balance of the vote account at the given address",
                 type_: "gauge",
                 metrics: banks_with_commitments.for_each_commitment(|bank| {
@@ -121,7 +121,7 @@ pub fn write_cluster_metrics<W: io::Write>(
         write_metric(
             out,
             &MetricFamily {
-                name: "solana_node_vote_credits",
+                name: "solana_validator_vote_credits",
                 help: "The total number of vote credits credited to this vote account",
                 type_: "gauge",
                 metrics: banks_with_commitments.for_each_commitment(|bank| {

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -60,9 +60,8 @@ impl ValidatorVoteInfo {
                 help:
                     "The voted-on slot of the validator's last vote that got included in the chain",
                 type_: "gauge",
-                metrics: vec![
-                    Metric::new(self.last_vote).with_label("pubkey", self.vote_address.to_string())
-                ],
+                metrics: vec![Metric::new(self.last_vote)
+                    .with_label("vote_account", self.vote_address.to_string())],
             },
         )?;
         // Validator rewards go to vote account, we use this to track our own
@@ -73,7 +72,8 @@ impl ValidatorVoteInfo {
                 name: "solana_node_vote_balance_sol",
                 help: "The current node's vote account balance",
                 type_: "gauge",
-                metrics: vec![Metric::new_sol(self.balance.clone())],
+                metrics: vec![Metric::new_sol(self.balance.clone())
+                    .with_label("vote_account", self.vote_address.to_string())],
             },
         )
     }

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -13,6 +13,7 @@ use std::{collections::HashSet, io, sync::Arc};
 struct ValidatorVoteInfo {
     balance: Lamports,
     last_vote: Slot,
+    vote_credits: u64,
 }
 
 fn get_vote_state(bank: &Bank, vote_pubkey: &Pubkey) -> Option<ValidatorVoteInfo> {
@@ -24,7 +25,12 @@ fn get_vote_state(bank: &Bank, vote_pubkey: &Pubkey) -> Option<ValidatorVoteInfo
 
     let last_vote = vote_state.votes.back()?.slot;
     let balance = Lamports(bank.get_balance(&vote_pubkey));
-    Some(ValidatorVoteInfo { balance, last_vote })
+    let vote_credits = vote_state.credits();
+    Some(ValidatorVoteInfo {
+        balance,
+        last_vote,
+        vote_credits,
+    })
 }
 
 pub fn write_cluster_metrics<W: io::Write>(
@@ -54,7 +60,7 @@ pub fn write_cluster_metrics<W: io::Write>(
         out,
         &MetricFamily {
             name: "solana_node_identity_balance_sol",
-            help: "The node's finalized identity balance",
+            help: "The balance of the node's identity account",
             type_: "gauge",
             metrics: banks_with_commitments
                 .for_each_commitment(|bank| {

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -71,7 +71,7 @@ impl ValidatorVoteInfo {
                 name: "solana_node_vote_balance_sol",
                 help: "The current node's vote account balance",
                 type_: "gauge",
-                metrics: vec![Metric::new_sol(self.balance)],
+                metrics: vec![Metric::new_sol(self.balance.clone())],
             },
         )
     }

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -14,6 +14,7 @@ struct ValidatorVoteInfo {
     balance: Lamports,
     last_vote: Slot,
     vote_credits: u64,
+    identity: Pubkey,
 }
 
 fn get_vote_state(bank: &Bank, vote_pubkey: &Pubkey) -> Option<ValidatorVoteInfo> {
@@ -30,6 +31,7 @@ fn get_vote_state(bank: &Bank, vote_pubkey: &Pubkey) -> Option<ValidatorVoteInfo
         balance,
         last_vote,
         vote_credits,
+        identity: vote_state.node_pubkey,
     })
 }
 
@@ -94,7 +96,7 @@ pub fn write_cluster_metrics<W: io::Write>(
                     let vote_info = get_vote_state(bank, vote_account)?;
                     Some(
                         Metric::new(vote_info.last_vote)
-                            .with_label("identity_account", identity_pubkey.to_string())
+                            .with_label("identity_account", vote_info.identity.to_string())
                             .with_label("vote_account", vote_account.to_string()),
                     )
                 }),
@@ -111,7 +113,7 @@ pub fn write_cluster_metrics<W: io::Write>(
                     let vote_info = get_vote_state(bank, vote_account)?;
                     Some(
                         Metric::new_sol(vote_info.balance)
-                            .with_label("identity_account", identity_pubkey.to_string())
+                            .with_label("identity_account", vote_info.identity.to_string())
                             .with_label("vote_account", vote_account.to_string()),
                     )
                 }),
@@ -128,7 +130,7 @@ pub fn write_cluster_metrics<W: io::Write>(
                     let vote_info = get_vote_state(bank, vote_account)?;
                     Some(
                         Metric::new(vote_info.vote_credits)
-                            .with_label("identity_account", identity_pubkey.to_string())
+                            .with_label("identity_account", vote_info.identity.to_string())
                             .with_label("vote_account", vote_account.to_string()),
                     )
                 }),

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -28,11 +28,7 @@ impl ValidatorVoteInfo {
                 if identity_pubkey != &vote_state.node_pubkey {
                     return None;
                 }
-                let last_vote = if let Some(vote) = vote_state.votes.iter().last() {
-                    Some(vote.slot)
-                } else {
-                    None
-                }?;
+                let last_vote = vote_state.votes.back()?.slot;
                 let vote_balance = Lamports(bank.get_balance(&vote_pubkey));
                 Some(ValidatorVoteInfo {
                     vote_address: vote_pubkey,

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -46,7 +46,9 @@ impl ValidatorVoteInfo {
                 name: "solana_node_vote_public_key_info",
                 help: "The current Solana node's vote public key",
                 type_: "count",
-                metrics: vec![Metric::new(1).with_label("vote", self.vote_address.to_string())],
+                metrics: vec![
+                    Metric::new(1).with_label("vote_account", self.vote_address.to_string())
+                ],
             },
         )?;
         // We can use this metric to track if the validator is making progress

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -106,7 +106,7 @@ pub fn write_cluster_metrics<W: io::Write>(
         write_metric(
             out,
             &MetricFamily {
-                name: "solana_validator_vote_balance_sol",
+                name: "solana_validator_vote_account_balance_sol",
                 help: "The balance of the vote account at the given address",
                 type_: "gauge",
                 metrics: banks_with_commitments.for_each_commitment(|bank| {

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -62,14 +62,12 @@ pub fn write_cluster_metrics<W: io::Write>(
             name: "solana_node_identity_balance_sol",
             help: "The balance of the node's identity account",
             type_: "gauge",
-            metrics: banks_with_commitments
-                .for_each_commitment(|bank| {
-                    Some(
-                        Metric::new_sol(Lamports(bank.get_balance(&identity_pubkey)))
-                            .with_label("identity_account", identity_pubkey.to_string()),
-                    )
-                })
-                .unwrap(),
+            metrics: banks_with_commitments.for_each_commitment(|bank| {
+                Some(
+                    Metric::new_sol(Lamports(bank.get_balance(&identity_pubkey)))
+                        .with_label("identity_account", identity_pubkey.to_string()),
+                )
+            }),
         },
     )?;
 
@@ -85,47 +83,57 @@ pub fn write_cluster_metrics<W: io::Write>(
 
     // Vote accounts information
     for vote_account in vote_accounts.iter() {
-        // We use this metric to track if the validator is making progress by
-        // voting on the last slots.
-        let metrics = banks_with_commitments.for_each_commitment(|bank| {
-            let vote_info = get_vote_state(bank, vote_account)?;
-            Some(
-                Metric::new(vote_info.last_vote)
-                    .with_label("identity_account", identity_pubkey.to_string())
-                    .with_label("vote_account", vote_account.to_string()),
-            )
-        });
-        if let Some(last_voted_slot_metrics) = metrics {
-            write_metric(
-                out,
-                &MetricFamily {
-                    name: "solana_node_last_vote_slot",
-                    help:
-                        "The voted-on slot of the validator's last vote that got included in the chain",
-                    type_: "gauge",
-                    metrics: last_voted_slot_metrics,
-                },
-            )?;
+        write_metric(
+            out,
+            &MetricFamily {
+                name: "solana_node_last_vote_slot",
+                help:
+                    "The voted-on slot of the validator's last vote that got included in the chain",
+                type_: "gauge",
+                metrics: banks_with_commitments.for_each_commitment(|bank| {
+                    let vote_info = get_vote_state(bank, vote_account)?;
+                    Some(
+                        Metric::new(vote_info.last_vote)
+                            .with_label("identity_account", identity_pubkey.to_string())
+                            .with_label("vote_account", vote_account.to_string()),
+                    )
+                }),
+            },
+        )?;
 
-            write_metric(
-                out,
-                &MetricFamily {
-                    name: "solana_node_vote_balance_sol",
-                    help: "The current node's vote account balance",
-                    type_: "gauge",
-                    metrics: banks_with_commitments
-                        .for_each_commitment(|bank| {
-                            let vote_info = get_vote_state(bank, vote_account)?;
-                            Some(
-                                Metric::new_sol(vote_info.balance)
-                                    .with_label("identity_account", identity_pubkey.to_string())
-                                    .with_label("vote_account", vote_account.to_string()),
-                            )
-                        })
-                        .unwrap(),
-                },
-            )?;
-        }
+        write_metric(
+            out,
+            &MetricFamily {
+                name: "solana_node_vote_balance_sol",
+                help: "The current node's vote account balance",
+                type_: "gauge",
+                metrics: banks_with_commitments.for_each_commitment(|bank| {
+                    let vote_info = get_vote_state(bank, vote_account)?;
+                    Some(
+                        Metric::new_sol(vote_info.balance)
+                            .with_label("identity_account", identity_pubkey.to_string())
+                            .with_label("vote_account", vote_account.to_string()),
+                    )
+                }),
+            },
+        )?;
+
+        write_metric(
+            out,
+            &MetricFamily {
+                name: "solana_node_vote_credits",
+                help: "The current node's vote vote credits for current epoch",
+                type_: "gauge",
+                metrics: banks_with_commitments.for_each_commitment(|bank| {
+                    let vote_info = get_vote_state(bank, vote_account)?;
+                    Some(
+                        Metric::new(vote_info.vote_credits)
+                            .with_label("identity_account", identity_pubkey.to_string())
+                            .with_label("vote_account", vote_account.to_string()),
+                    )
+                }),
+            },
+        )?;
     }
 
     Ok(())

--- a/prometheus/src/lib.rs
+++ b/prometheus/src/lib.rs
@@ -7,6 +7,7 @@ use banks_with_commitments::BanksWithCommitments;
 use solana_gossip::cluster_info::ClusterInfo;
 use std::sync::Arc;
 
+#[derive(Clone)]
 pub struct Lamports(pub u64);
 
 pub fn render_prometheus(

--- a/prometheus/src/lib.rs
+++ b/prometheus/src/lib.rs
@@ -8,7 +8,7 @@ use solana_gossip::cluster_info::ClusterInfo;
 use solana_sdk::pubkey::Pubkey;
 use std::{collections::HashSet, sync::Arc};
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct Lamports(pub u64);
 
 pub fn render_prometheus(

--- a/prometheus/src/lib.rs
+++ b/prometheus/src/lib.rs
@@ -5,7 +5,8 @@ mod utils;
 
 use banks_with_commitments::BanksWithCommitments;
 use solana_gossip::cluster_info::ClusterInfo;
-use std::sync::Arc;
+use solana_sdk::pubkey::Pubkey;
+use std::{collections::HashSet, sync::Arc};
 
 #[derive(Clone)]
 pub struct Lamports(pub u64);
@@ -13,6 +14,7 @@ pub struct Lamports(pub u64);
 pub fn render_prometheus(
     banks_with_commitments: BanksWithCommitments,
     cluster_info: &Arc<ClusterInfo>,
+    vote_accounts: &Arc<HashSet<Pubkey>>,
 ) -> Vec<u8> {
     // There are 3 levels of commitment for a bank:
     // - finalized: most recent block *confirmed* by supermajority of the
@@ -22,7 +24,12 @@ pub fn render_prometheus(
     // - processed: most recent block.
     let mut out: Vec<u8> = Vec::new();
     bank_metrics::write_bank_metrics(&banks_with_commitments, &mut out).expect("IO error");
-    cluster_metrics::write_cluster_metrics(&banks_with_commitments, &cluster_info, &mut out)
-        .expect("IO error");
+    cluster_metrics::write_cluster_metrics(
+        &banks_with_commitments,
+        &cluster_info,
+        vote_accounts,
+        &mut out,
+    )
+    .expect("IO error");
     out
 }

--- a/prometheus/src/utils.rs
+++ b/prometheus/src/utils.rs
@@ -251,7 +251,7 @@ mod test {
                 name: "goats_teleported_total",
                 help: "Number of goats teleported since launch.",
                 type_: "counter",
-                metrics: vec![Metric::new(10).at(t)],
+                metrics: vec![Metric::new(10)],
             },
         )
         .unwrap();

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -74,7 +74,7 @@ struct RpcRequestMiddleware {
     bank_forks: Arc<RwLock<BankForks>>,
     health: Arc<RpcHealth>,
     block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
-    observable_vote_accounts: Arc<HashSet<Pubkey>>,
+    vote_accounts_to_monitor: Arc<HashSet<Pubkey>>,
 }
 
 impl RpcRequestMiddleware {
@@ -84,7 +84,7 @@ impl RpcRequestMiddleware {
         bank_forks: Arc<RwLock<BankForks>>,
         health: Arc<RpcHealth>,
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
-        observable_vote_accounts: Arc<HashSet<Pubkey>>,
+        vote_accounts_to_monitor: Arc<HashSet<Pubkey>>,
     ) -> Self {
         Self {
             ledger_path,
@@ -100,7 +100,7 @@ impl RpcRequestMiddleware {
             bank_forks,
             health,
             block_commitment_cache,
-            observable_vote_accounts,
+            vote_accounts_to_monitor,
         }
     }
 
@@ -305,7 +305,7 @@ impl RequestMiddleware for RpcRequestMiddleware {
                         .body(hyper::Body::from(render_prometheus(
                             banks_with_commitment,
                             &self.health.cluster_info,
-                            &self.observable_vote_accounts,
+                            &self.vote_accounts_to_monitor,
                         )))
                         .unwrap()
                         .into()
@@ -361,7 +361,7 @@ impl JsonRpcService {
         leader_schedule_cache: Arc<LeaderScheduleCache>,
         connection_cache: Arc<ConnectionCache>,
         current_transaction_status_slot: Arc<AtomicU64>,
-        observable_vote_accounts: Arc<HashSet<Pubkey>>,
+        vote_accounts_to_monitor: Arc<HashSet<Pubkey>>,
     ) -> Self {
         info!("rpc bound to {:?}", rpc_addr);
         info!("rpc configuration: {:?}", config);
@@ -510,7 +510,7 @@ impl JsonRpcService {
                     bank_forks.clone(),
                     health.clone(),
                     block_commitment_cache.clone(),
-                    observable_vote_accounts,
+                    vote_accounts_to_monitor,
                 );
                 let server = ServerBuilder::with_meta_extractor(
                     io,

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -74,6 +74,7 @@ struct RpcRequestMiddleware {
     bank_forks: Arc<RwLock<BankForks>>,
     health: Arc<RpcHealth>,
     block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
+    observable_vote_accounts: Arc<HashSet<Pubkey>>,
 }
 
 impl RpcRequestMiddleware {
@@ -83,6 +84,7 @@ impl RpcRequestMiddleware {
         bank_forks: Arc<RwLock<BankForks>>,
         health: Arc<RpcHealth>,
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
+        observable_vote_accounts: Arc<HashSet<Pubkey>>,
     ) -> Self {
         Self {
             ledger_path,
@@ -98,6 +100,7 @@ impl RpcRequestMiddleware {
             bank_forks,
             health,
             block_commitment_cache,
+            observable_vote_accounts,
         }
     }
 
@@ -302,6 +305,7 @@ impl RequestMiddleware for RpcRequestMiddleware {
                         .body(hyper::Body::from(render_prometheus(
                             banks_with_commitment,
                             &self.health.cluster_info,
+                            &self.observable_vote_accounts,
                         )))
                         .unwrap()
                         .into()
@@ -357,6 +361,7 @@ impl JsonRpcService {
         leader_schedule_cache: Arc<LeaderScheduleCache>,
         connection_cache: Arc<ConnectionCache>,
         current_transaction_status_slot: Arc<AtomicU64>,
+        observable_vote_accounts: Arc<HashSet<Pubkey>>,
     ) -> Self {
         info!("rpc bound to {:?}", rpc_addr);
         info!("rpc configuration: {:?}", config);
@@ -505,6 +510,7 @@ impl JsonRpcService {
                     bank_forks.clone(),
                     health.clone(),
                     block_commitment_cache.clone(),
+                    observable_vote_accounts,
                 );
                 let server = ServerBuilder::with_meta_extractor(
                     io,
@@ -642,6 +648,7 @@ mod tests {
             Arc::new(LeaderScheduleCache::default()),
             connection_cache,
             Arc::new(AtomicU64::default()),
+            None,
         );
         let thread = rpc_service.thread_hdl.thread();
         assert_eq!(thread.name().unwrap(), "solana-jsonrpc");
@@ -688,6 +695,7 @@ mod tests {
             bank_forks.clone(),
             RpcHealth::stub(),
             block_commitment_cache,
+            None,
         );
         let rrm_with_snapshot_config = RpcRequestMiddleware::new(
             PathBuf::from("/"),
@@ -695,6 +703,7 @@ mod tests {
             bank_forks,
             RpcHealth::stub(),
             block_commitment_cache,
+            None,
         );
 
         assert!(rrm.is_file_get_path(DEFAULT_GENESIS_DOWNLOAD_PATH));
@@ -766,6 +775,7 @@ mod tests {
             create_bank_forks(),
             RpcHealth::stub(),
             Arc::new(RwLock::new(BlockCommitmentCache::default())),
+            None,
         );
 
         // File does not exist => request should fail.
@@ -822,6 +832,7 @@ mod tests {
             create_bank_forks(),
             RpcHealth::stub(),
             Arc::new(RwLock::new(BlockCommitmentCache::default())),
+            None,
         );
         assert_eq!(rm.health_check(), "ok");
     }
@@ -854,6 +865,7 @@ mod tests {
             create_bank_forks(),
             health,
             Arc::new(RwLock::new(BlockCommitmentCache::default())),
+            None,
         );
 
         // No account hashes for this node or any known validators

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -709,6 +709,7 @@ impl TestValidator {
             max_ledger_shreds: config.max_ledger_shreds,
             no_wait_for_vote_to_start_leader: true,
             accounts_db_config,
+            observable_vote_acounts: Arc::new(HashSet::from_iter(vec![vote_account_address])),
             ..ValidatorConfig::default_for_test()
         };
         if let Some(ref tower_storage) = config.tower_storage {

--- a/test-validator/src/lib.rs
+++ b/test-validator/src/lib.rs
@@ -709,7 +709,7 @@ impl TestValidator {
             max_ledger_shreds: config.max_ledger_shreds,
             no_wait_for_vote_to_start_leader: true,
             accounts_db_config,
-            observable_vote_acounts: Arc::new(HashSet::from_iter(vec![vote_account_address])),
+            vote_accounts_to_monitor: Arc::new(HashSet::from_iter(vec![vote_account_address])),
             ..ValidatorConfig::default_for_test()
         };
         if let Some(ref tower_storage) = config.tower_storage {

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -380,9 +380,8 @@ fn hardforks_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<Slot>> {
 
 fn get_vote_accounts_to_monitor(matches: &ArgMatches<'_>) -> HashSet<Pubkey> {
     let vote_account = if matches.is_present("vote_account") {
-        vec![pubkey_of(&matches, "vote_account").expect(
-            "Does not fail, as this is validated by Clap earlier.",
-        )()]
+        vec![pubkey_of(&matches, "vote_account")
+            .expect("Does not fail, as this is validated by Clap earlier.")]
     } else {
         vec![]
     };
@@ -2549,7 +2548,7 @@ pub fn main() {
         Keypair::new().pubkey()
     });
 
-    validator_config.vote_accounts_to_monitor = get_vote_accounts_to_monitor(&matches);
+    validator_config.vote_accounts_to_monitor = Arc::new(get_vote_accounts_to_monitor(&matches));
 
     let dynamic_port_range =
         solana_net_utils::parse_port_range(matches.value_of("dynamic_port_range").unwrap())

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -378,6 +378,22 @@ fn hardforks_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<Slot>> {
     }
 }
 
+fn get_observable_vote_accounts(matches: &ArgMatches<'_>) -> HashSet<Pubkey> {
+    let vote_account = if matches.is_present("vote_account") {
+        vec![pubkey_of(&matches, "vote_account").unwrap()]
+    } else {
+        vec![]
+    };
+    let mut monitor_vote_accounts = if matches.is_present("monitor_vote_account") {
+        let accounts = values_t_or_exit!(matches, "monitor_vote_account", Pubkey);
+        accounts.into_iter().collect::<HashSet<Pubkey>>()
+    } else {
+        HashSet::new()
+    };
+    monitor_vote_accounts.extend(vote_account.iter());
+    monitor_vote_accounts
+}
+
 fn validators_set(
     identity_pubkey: &Pubkey,
     matches: &ArgMatches<'_>,
@@ -1862,6 +1878,15 @@ pub fn main() {
             .after_help("Note: If this command exits with a non-zero status \
                          then this not a good time for a restart")
         )
+        .arg(
+            Arg::with_name("monitor_vote_account")
+            .long("monitor-vote-account")
+            .takes_value(true)
+            .value_name("MONITOR_VOTE_ACCOUNT")
+            .validator(is_pubkey)
+            .multiple(true)
+            .help("The vote accounts to inspect for prometheus metrics")
+        )
         .get_matches();
 
     let socket_addr_space = SocketAddrSpace::new(matches.is_present("allow_private_addr"));
@@ -2519,6 +2544,8 @@ pub fn main() {
         }
         Keypair::new().pubkey()
     });
+
+    validator_config.observable_vote_acounts = get_observable_vote_accounts(&matches);
 
     let dynamic_port_range =
         solana_net_utils::parse_port_range(matches.value_of("dynamic_port_range").unwrap())

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -378,9 +378,11 @@ fn hardforks_of(matches: &ArgMatches<'_>, name: &str) -> Option<Vec<Slot>> {
     }
 }
 
-fn get_observable_vote_accounts(matches: &ArgMatches<'_>) -> HashSet<Pubkey> {
+fn get_vote_accounts_to_monitor(matches: &ArgMatches<'_>) -> HashSet<Pubkey> {
     let vote_account = if matches.is_present("vote_account") {
-        vec![pubkey_of(&matches, "vote_account").unwrap()]
+        vec![pubkey_of(&matches, "vote_account").expect(
+            "Does not fail, as this is validated by Clap earlier.",
+        )()]
     } else {
         vec![]
     };
@@ -1882,10 +1884,12 @@ pub fn main() {
             Arg::with_name("monitor_vote_account")
             .long("monitor-vote-account")
             .takes_value(true)
-            .value_name("MONITOR_VOTE_ACCOUNT")
+            .value_name("PUBKEY")
             .validator(is_pubkey)
             .multiple(true)
-            .help("The vote accounts to inspect for prometheus metrics")
+            .help("Additional vote accounts expose Prometheus metrics about. \
+                   The validator's own vote account is always included implicitly \
+                   if there is one.")
         )
         .get_matches();
 
@@ -2545,7 +2549,7 @@ pub fn main() {
         Keypair::new().pubkey()
     });
 
-    validator_config.observable_vote_acounts = get_observable_vote_accounts(&matches);
+    validator_config.vote_accounts_to_monitor = get_vote_accounts_to_monitor(&matches);
 
     let dynamic_port_range =
         solana_net_utils::parse_port_range(matches.value_of("dynamic_port_range").unwrap())


### PR DESCRIPTION
Introduce metrics about the vote account. We can track the amount of rewards (balance of the vote account) and if the validator voted in the last slots.