### PR TITLE
Expose epoch schedule metrics in Prometheus

### DIFF
--- a/prometheus/src/bank_metrics.rs
+++ b/prometheus/src/bank_metrics.rs
@@ -3,6 +3,8 @@ use crate::{
     utils::{write_metric, Metric, MetricFamily},
 };
 use std::io;
+use solana_sdk::sysvar;
+use solana_sdk::sysvar::epoch_schedule::EpochSchedule;
 
 pub fn write_bank_metrics<W: io::Write>(
     banks_with_commitments: &BanksWithCommitments,
@@ -26,6 +28,46 @@ pub fn write_bank_metrics<W: io::Write>(
             type_: "gauge",
             metrics: banks_with_commitments
                 .for_each_commitment(|bank| Some(Metric::new(bank.clock().epoch))),
+        },
+    )?;
+    write_metric(
+        out,
+        &MetricFamily {
+            name: "solana_block_epoch_start_slot",
+            help: "The first slot in the current epoch",
+            type_: "gauge",
+            metrics: banks_with_commitments
+                .for_each_commitment(|bank| {
+                    // Note, the bank actually has a field that holds the EpochSchedule,
+                    // but it is not public, so we can't easily access it  here. We could
+                    // make it public, but to make our patches less invasive, load the
+                    // epoch schedule from the sysvar instead. It should always exist.
+                    let epoch_schedule: EpochSchedule = bank
+                        .get_account(&sysvar::epoch_schedule::id())?
+                        .deserialize_data().ok()?;
+                    let clock = bank.clock();
+                    Some(Metric::new(epoch_schedule.get_first_slot_in_epoch(clock.epoch)))
+                }),
+        },
+    )?;
+    write_metric(
+        out,
+        &MetricFamily {
+            name: "solana_block_epoch_slots_total",
+            help: "The duration of the current epoch, in slots.",
+            type_: "gauge",
+            metrics: banks_with_commitments
+                .for_each_commitment(|bank| {
+                    // Note, the bank actually has a field that holds the EpochSchedule,
+                    // but it is not public, so we can't easily access it  here. We could
+                    // make it public, but to make our patches less invasive, load the
+                    // epoch schedule from the sysvar instead. It should always exist.
+                    let epoch_schedule: EpochSchedule = bank
+                        .get_account(&sysvar::epoch_schedule::id())?
+                        .deserialize_data().ok()?;
+                    let clock = bank.clock();
+                    Some(Metric::new(epoch_schedule.get_slots_in_epoch(clock.epoch)))
+                }),
         },
     )?;
     write_metric(


### PR DESCRIPTION
With the epoch start slots and the number of slots in the epoch (and the current slot, which we already had), we can infer/estimate:

 * Epoch progress percentage
 * Slots left until the next epoch
 * Time left until the next epoch (from slot height increase)

These are useful metrics to have about the network. We have them in the Solido maintenance daemon already, but I’d like to have them first-hand.