### PR TITLE
Add validator name label to metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5855,7 +5855,12 @@ dependencies = [
 name = "solana-prometheus"
 version = "1.10.28"
 dependencies = [
+ "bincode",
  "jsonrpc-http-server",
+ "serde",
+ "serde_json",
+ "solana-account-decoder",
+ "solana-config-program",
  "solana-gossip",
  "solana-runtime",
  "solana-sdk 1.10.32",

--- a/prometheus/Cargo.toml
+++ b/prometheus/Cargo.toml
@@ -9,10 +9,15 @@ edition = "2021"
 
 [dependencies]
 jsonrpc-http-server = "18.0.0"
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.79"
 solana-gossip = { path = "../gossip" }
 solana-runtime = { path = "../runtime" }
 solana-sdk = { path = "../sdk" }
 solana-vote-program = { path = "../programs/vote" }
+solana-config-program = { path = "../programs/config" }
+bincode = "1.3.3"
+solana-account-decoder = { path = "../account-decoder" }
 
 [lib]
 crate-type = ["lib"]

--- a/prometheus/src/bank_metrics.rs
+++ b/prometheus/src/bank_metrics.rs
@@ -2,9 +2,9 @@ use crate::{
     banks_with_commitments::BanksWithCommitments,
     utils::{write_metric, Metric, MetricFamily},
 };
-use std::io;
 use solana_sdk::sysvar;
 use solana_sdk::sysvar::epoch_schedule::EpochSchedule;
+use std::io;
 
 pub fn write_bank_metrics<W: io::Write>(
     banks_with_commitments: &BanksWithCommitments,
@@ -36,18 +36,20 @@ pub fn write_bank_metrics<W: io::Write>(
             name: "solana_block_epoch_start_slot",
             help: "The first slot in the current epoch",
             type_: "gauge",
-            metrics: banks_with_commitments
-                .for_each_commitment(|bank| {
-                    // Note, the bank actually has a field that holds the EpochSchedule,
-                    // but it is not public, so we can't easily access it  here. We could
-                    // make it public, but to make our patches less invasive, load the
-                    // epoch schedule from the sysvar instead. It should always exist.
-                    let epoch_schedule: EpochSchedule = bank
-                        .get_account(&sysvar::epoch_schedule::id())?
-                        .deserialize_data().ok()?;
-                    let clock = bank.clock();
-                    Some(Metric::new(epoch_schedule.get_first_slot_in_epoch(clock.epoch)))
-                }),
+            metrics: banks_with_commitments.for_each_commitment(|bank| {
+                // Note, the bank actually has a field that holds the EpochSchedule,
+                // but it is not public, so we can't easily access it  here. We could
+                // make it public, but to make our patches less invasive, load the
+                // epoch schedule from the sysvar instead. It should always exist.
+                let epoch_schedule: EpochSchedule = bank
+                    .get_account(&sysvar::epoch_schedule::id())?
+                    .deserialize_data()
+                    .ok()?;
+                let clock = bank.clock();
+                Some(Metric::new(
+                    epoch_schedule.get_first_slot_in_epoch(clock.epoch),
+                ))
+            }),
         },
     )?;
     write_metric(
@@ -56,18 +58,18 @@ pub fn write_bank_metrics<W: io::Write>(
             name: "solana_block_epoch_slots_total",
             help: "The duration of the current epoch, in slots.",
             type_: "gauge",
-            metrics: banks_with_commitments
-                .for_each_commitment(|bank| {
-                    // Note, the bank actually has a field that holds the EpochSchedule,
-                    // but it is not public, so we can't easily access it  here. We could
-                    // make it public, but to make our patches less invasive, load the
-                    // epoch schedule from the sysvar instead. It should always exist.
-                    let epoch_schedule: EpochSchedule = bank
-                        .get_account(&sysvar::epoch_schedule::id())?
-                        .deserialize_data().ok()?;
-                    let clock = bank.clock();
-                    Some(Metric::new(epoch_schedule.get_slots_in_epoch(clock.epoch)))
-                }),
+            metrics: banks_with_commitments.for_each_commitment(|bank| {
+                // Note, the bank actually has a field that holds the EpochSchedule,
+                // but it is not public, so we can't easily access it  here. We could
+                // make it public, but to make our patches less invasive, load the
+                // epoch schedule from the sysvar instead. It should always exist.
+                let epoch_schedule: EpochSchedule = bank
+                    .get_account(&sysvar::epoch_schedule::id())?
+                    .deserialize_data()
+                    .ok()?;
+                let clock = bank.clock();
+                Some(Metric::new(epoch_schedule.get_slots_in_epoch(clock.epoch)))
+            }),
         },
     )?;
     write_metric(

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -1,4 +1,3 @@
-use solana_config_program::ConfigKeys;
 use solana_gossip::cluster_info::ClusterInfo;
 use solana_runtime::bank::Bank;
 use solana_sdk::{clock::Slot, pubkey::Pubkey};
@@ -9,13 +8,8 @@ use crate::{
     utils::{write_metric, Metric, MetricFamily},
     Lamports,
 };
-use bincode;
-use serde::Deserialize;
-use serde_json;
-use solana_runtime::accounts_index::ScanConfig;
-use solana_sdk::account::ReadableAccount;
-use std::collections::HashMap;
 use std::{collections::HashSet, io, sync::Arc};
+use crate::identity_info::{IdentityInfoMap, ValidatorInfo};
 
 struct ValidatorVoteInfo {
     balance: Lamports,
@@ -23,16 +17,10 @@ struct ValidatorVoteInfo {
     vote_credits: u64,
     identity: Pubkey,
     activated_stake: Lamports,
-    validator_info: ValidatorInfo,
+    validator_info: Option<ValidatorInfo>,
 }
 
-/// ValidatorInfo represents selected fields from the config account data.
-#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
-pub struct ValidatorInfo {
-    pub name: String,
-}
-
-fn get_vote_state(bank: &Bank, vote_pubkey: &Pubkey) -> Option<ValidatorVoteInfo> {
+fn get_vote_state(bank: &Bank, vote_pubkey: &Pubkey, identity_info: &Arc<IdentityInfoMap>) -> Option<ValidatorVoteInfo> {
     let default_vote_state = VoteState::default();
     let vote_accounts = bank.vote_accounts();
     let (activated_stake, vote_account) = vote_accounts.get(vote_pubkey)?;
@@ -41,17 +29,7 @@ fn get_vote_state(bank: &Bank, vote_pubkey: &Pubkey) -> Option<ValidatorVoteInfo
 
     let identity = vote_state.node_pubkey;
 
-    let validator_info: ValidatorInfo = match get_validator_info_accounts(bank) {
-        None => ValidatorInfo {
-            name: "unknown".to_string(),
-        },
-        Some(mut info_map) => match info_map.remove(&identity) {
-            None => ValidatorInfo {
-                name: "unknown".to_string(),
-            },
-            Some(info) => info,
-        },
-    };
+    let validator_info = identity_info.get(&identity);
 
     let last_vote = vote_state.votes.back()?.slot;
     let balance = Lamports(bank.get_balance(&vote_pubkey));
@@ -62,86 +40,15 @@ fn get_vote_state(bank: &Bank, vote_pubkey: &Pubkey) -> Option<ValidatorVoteInfo
         vote_credits,
         identity,
         activated_stake: Lamports(*activated_stake),
-        validator_info,
+        validator_info: validator_info.cloned(),
     })
-}
-
-/// Return a map from validator identity account to ValidatorInfo.
-///
-/// To get the validator info (the validator metadata, such as name and Keybase
-/// username), we have to extract that from the config account that stores the
-/// validator info for a particular validator. But there is no way a priori to
-/// know the address of the config account for a given validator; the only way
-/// is to enumerate all config accounts and then find the one you are looking
-/// for. This function builds a map from identity account to validator info.
-pub fn get_validator_info_accounts(bank: &Bank) -> Option<HashMap<Pubkey, ValidatorInfo>> {
-    use solana_sdk::config::program as config_program;
-
-    let all_accounts = bank
-        .get_program_accounts(&config_program::id(), &ScanConfig::default())
-        .expect("failed to get program accounts");
-
-    let mut mapping = HashMap::new();
-
-    // Due to the structure of validator info (config accounts pointing to identity
-    // accounts), it is possible for multiple config accounts to describe the same
-    // validator. This is invalid, if it happens, we wouldn't know which config
-    // account is the right one, so instead of making an arbitrary decision, we
-    // ignore all validator infos for that identity.
-    let mut bad_identities = HashSet::new();
-
-    for (_, account) in &all_accounts {
-        if let Some((validator_identity, info)) = deserialize_validator_info(account.data()) {
-            let old_config_addr = mapping.insert(validator_identity, info);
-            if old_config_addr.is_some() {
-                bad_identities.insert(validator_identity);
-            }
-        }
-    }
-
-    for bad_identity in &bad_identities {
-        mapping.remove(bad_identity);
-    }
-
-    Some(mapping)
-}
-
-/// Deserialize a config account that contains validator info.
-///
-/// Returns the validator identity account address, and the validator info for
-/// that validator.
-pub fn deserialize_validator_info(account_data: &[u8]) -> Option<(Pubkey, ValidatorInfo)> {
-    use solana_account_decoder::validator_info;
-
-    let key_list: ConfigKeys = bincode::deserialize(account_data).ok()?;
-
-    if !key_list.keys.contains(&(validator_info::id(), false)) {
-        return None;
-    }
-
-    // The validator identity pubkey lives at index 1.
-    let (validator_identity, identity_signed_config) = key_list.keys[1];
-    if !identity_signed_config {
-        return None;
-    }
-
-    // A config account stores a list of (pubkey, bool) pairs, followed by json
-    // data. To figure out where the json data starts, we need to know the size
-    // fo the key list. The json data is not stored directly, it is serialized
-    // with bincode as a string.
-    let key_list_len = bincode::serialized_size(&key_list)
-        .expect("We deserialized it, therefore it must be serializable.")
-        as usize;
-    let json_data: String = bincode::deserialize(&account_data[key_list_len..]).ok()?;
-    let validator_info: ValidatorInfo = serde_json::from_str(&json_data).ok()?;
-
-    Some((validator_identity, validator_info))
 }
 
 pub fn write_cluster_metrics<W: io::Write>(
     banks_with_commitments: &BanksWithCommitments,
     cluster_info: &Arc<ClusterInfo>,
     vote_accounts: &Arc<HashSet<Pubkey>>,
+    identity_info: &Arc<IdentityInfoMap>,
     out: &mut W,
 ) -> io::Result<()> {
     let identity_pubkey = cluster_info.id();
@@ -196,12 +103,15 @@ pub fn write_cluster_metrics<W: io::Write>(
                     "The voted-on slot of the validator's last vote that got included in the chain",
                 type_: "gauge",
                 metrics: banks_with_commitments.for_each_commitment(|bank| {
-                    let vote_info = get_vote_state(bank, vote_account)?;
+                    let vote_info = get_vote_state(bank, vote_account, identity_info)?;
                     Some(
                         Metric::new(vote_info.last_vote)
                             .with_label("identity_account", vote_info.identity.to_string())
                             .with_label("vote_account", vote_account.to_string())
-                            .with_label("validator_name", vote_info.validator_info.name),
+                            .with_optional_label(
+                                "validator_name",
+                                vote_info.validator_info.map(|v| v.name),
+                            ),
                     )
                 }),
             },
@@ -214,12 +124,15 @@ pub fn write_cluster_metrics<W: io::Write>(
                 help: "The balance of the vote account at the given address",
                 type_: "gauge",
                 metrics: banks_with_commitments.for_each_commitment(|bank| {
-                    let vote_info = get_vote_state(bank, vote_account)?;
+                    let vote_info = get_vote_state(bank, vote_account, identity_info)?;
                     Some(
                         Metric::new_sol(vote_info.balance)
                             .with_label("identity_account", vote_info.identity.to_string())
                             .with_label("vote_account", vote_account.to_string())
-                            .with_label("validator_name", vote_info.validator_info.name),
+                            .with_optional_label(
+                                "validator_name",
+                                vote_info.validator_info.map(|v| v.name),
+                            ),
                     )
                 }),
             },
@@ -232,12 +145,15 @@ pub fn write_cluster_metrics<W: io::Write>(
                 help: "The total number of vote credits credited to this vote account",
                 type_: "gauge",
                 metrics: banks_with_commitments.for_each_commitment(|bank| {
-                    let vote_info = get_vote_state(bank, vote_account)?;
+                    let vote_info = get_vote_state(bank, vote_account, identity_info)?;
                     Some(
                         Metric::new(vote_info.vote_credits)
                             .with_label("identity_account", vote_info.identity.to_string())
                             .with_label("vote_account", vote_account.to_string())
-                            .with_label("validator_name", vote_info.validator_info.name),
+                            .with_optional_label(
+                                "validator_name",
+                                vote_info.validator_info.map(|v| v.name),
+                            ),
                     )
                 }),
             },
@@ -250,12 +166,15 @@ pub fn write_cluster_metrics<W: io::Write>(
                 help: "The total amount of Sol actively staked to this validator",
                 type_: "gauge",
                 metrics: banks_with_commitments.for_each_commitment(|bank| {
-                    let vote_info = get_vote_state(bank, vote_account)?;
+                    let vote_info = get_vote_state(bank, vote_account, identity_info)?;
                     Some(
                         Metric::new_sol(vote_info.activated_stake)
                             .with_label("identity_account", vote_info.identity.to_string())
                             .with_label("vote_account", vote_account.to_string())
-                            .with_label("validator_name", vote_info.validator_info.name),
+                            .with_optional_label(
+                                "validator_name",
+                                vote_info.validator_info.map(|v| v.name),
+                            ),
                     )
                 }),
             },

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -1,3 +1,4 @@
+use solana_config_program::ConfigKeys;
 use solana_gossip::cluster_info::ClusterInfo;
 use solana_runtime::bank::Bank;
 use solana_sdk::{clock::Slot, pubkey::Pubkey};
@@ -8,6 +9,12 @@ use crate::{
     utils::{write_metric, Metric, MetricFamily},
     Lamports,
 };
+use bincode;
+use serde::Deserialize;
+use serde_json;
+use solana_runtime::accounts_index::ScanConfig;
+use solana_sdk::account::ReadableAccount;
+use std::collections::HashMap;
 use std::{collections::HashSet, io, sync::Arc};
 
 struct ValidatorVoteInfo {
@@ -16,6 +23,13 @@ struct ValidatorVoteInfo {
     vote_credits: u64,
     identity: Pubkey,
     activated_stake: Lamports,
+    validator_info: ValidatorInfo,
+}
+
+/// ValidatorInfo represents selected fields from the config account data.
+#[derive(Debug, Deserialize, Clone, Eq, PartialEq)]
+pub struct ValidatorInfo {
+    pub name: String,
 }
 
 fn get_vote_state(bank: &Bank, vote_pubkey: &Pubkey) -> Option<ValidatorVoteInfo> {
@@ -25,6 +39,20 @@ fn get_vote_state(bank: &Bank, vote_pubkey: &Pubkey) -> Option<ValidatorVoteInfo
     let vote_state = vote_account.vote_state();
     let vote_state = vote_state.as_ref().unwrap_or(&default_vote_state);
 
+    let identity = vote_state.node_pubkey;
+
+    let validator_info: ValidatorInfo = match get_validator_info_accounts(bank) {
+        None => ValidatorInfo {
+            name: "unknown".to_string(),
+        },
+        Some(mut info_map) => match info_map.remove(&identity) {
+            None => ValidatorInfo {
+                name: "unknown".to_string(),
+            },
+            Some(info) => info,
+        },
+    };
+
     let last_vote = vote_state.votes.back()?.slot;
     let balance = Lamports(bank.get_balance(&vote_pubkey));
     let vote_credits = vote_state.credits();
@@ -32,9 +60,82 @@ fn get_vote_state(bank: &Bank, vote_pubkey: &Pubkey) -> Option<ValidatorVoteInfo
         balance,
         last_vote,
         vote_credits,
-        identity: vote_state.node_pubkey,
+        identity,
         activated_stake: Lamports(*activated_stake),
+        validator_info,
     })
+}
+
+/// Return a map from validator identity account to ValidatorInfo.
+///
+/// To get the validator info (the validator metadata, such as name and Keybase
+/// username), we have to extract that from the config account that stores the
+/// validator info for a particular validator. But there is no way a priori to
+/// know the address of the config account for a given validator; the only way
+/// is to enumerate all config accounts and then find the one you are looking
+/// for. This function builds a map from identity account to validator info.
+pub fn get_validator_info_accounts(bank: &Bank) -> Option<HashMap<Pubkey, ValidatorInfo>> {
+    use solana_sdk::config::program as config_program;
+
+    let all_accounts = bank
+        .get_program_accounts(&config_program::id(), &ScanConfig::default())
+        .expect("failed to get program accounts");
+
+    let mut mapping = HashMap::new();
+
+    // Due to the structure of validator info (config accounts pointing to identity
+    // accounts), it is possible for multiple config accounts to describe the same
+    // validator. This is invalid, if it happens, we wouldn't know which config
+    // account is the right one, so instead of making an arbitrary decision, we
+    // ignore all validator infos for that identity.
+    let mut bad_identities = HashSet::new();
+
+    for (_, account) in &all_accounts {
+        if let Some((validator_identity, info)) = deserialize_validator_info(account.data()) {
+            let old_config_addr = mapping.insert(validator_identity, info);
+            if old_config_addr.is_some() {
+                bad_identities.insert(validator_identity);
+            }
+        }
+    }
+
+    for bad_identity in &bad_identities {
+        mapping.remove(bad_identity);
+    }
+
+    Some(mapping)
+}
+
+/// Deserialize a config account that contains validator info.
+///
+/// Returns the validator identity account address, and the validator info for
+/// that validator.
+pub fn deserialize_validator_info(account_data: &[u8]) -> Option<(Pubkey, ValidatorInfo)> {
+    use solana_account_decoder::validator_info;
+
+    let key_list: ConfigKeys = bincode::deserialize(account_data).ok()?;
+
+    if !key_list.keys.contains(&(validator_info::id(), false)) {
+        return None;
+    }
+
+    // The validator identity pubkey lives at index 1.
+    let (validator_identity, identity_signed_config) = key_list.keys[1];
+    if !identity_signed_config {
+        return None;
+    }
+
+    // A config account stores a list of (pubkey, bool) pairs, followed by json
+    // data. To figure out where the json data starts, we need to know the size
+    // fo the key list. The json data is not stored directly, it is serialized
+    // with bincode as a string.
+    let key_list_len = bincode::serialized_size(&key_list)
+        .expect("We deserialized it, therefore it must be serializable.")
+        as usize;
+    let json_data: String = bincode::deserialize(&account_data[key_list_len..]).ok()?;
+    let validator_info: ValidatorInfo = serde_json::from_str(&json_data).ok()?;
+
+    Some((validator_identity, validator_info))
 }
 
 pub fn write_cluster_metrics<W: io::Write>(
@@ -99,7 +200,8 @@ pub fn write_cluster_metrics<W: io::Write>(
                     Some(
                         Metric::new(vote_info.last_vote)
                             .with_label("identity_account", vote_info.identity.to_string())
-                            .with_label("vote_account", vote_account.to_string()),
+                            .with_label("vote_account", vote_account.to_string())
+                            .with_label("validator_name", vote_info.validator_info.name),
                     )
                 }),
             },
@@ -116,7 +218,8 @@ pub fn write_cluster_metrics<W: io::Write>(
                     Some(
                         Metric::new_sol(vote_info.balance)
                             .with_label("identity_account", vote_info.identity.to_string())
-                            .with_label("vote_account", vote_account.to_string()),
+                            .with_label("vote_account", vote_account.to_string())
+                            .with_label("validator_name", vote_info.validator_info.name),
                     )
                 }),
             },
@@ -133,7 +236,8 @@ pub fn write_cluster_metrics<W: io::Write>(
                     Some(
                         Metric::new(vote_info.vote_credits)
                             .with_label("identity_account", vote_info.identity.to_string())
-                            .with_label("vote_account", vote_account.to_string()),
+                            .with_label("vote_account", vote_account.to_string())
+                            .with_label("validator_name", vote_info.validator_info.name),
                     )
                 }),
             },
@@ -150,7 +254,8 @@ pub fn write_cluster_metrics<W: io::Write>(
                     Some(
                         Metric::new_sol(vote_info.activated_stake)
                             .with_label("identity_account", vote_info.identity.to_string())
-                            .with_label("vote_account", vote_account.to_string()),
+                            .with_label("vote_account", vote_account.to_string())
+                            .with_label("validator_name", vote_info.validator_info.name),
                     )
                 }),
             },

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -3,13 +3,13 @@ use solana_runtime::bank::Bank;
 use solana_sdk::{clock::Slot, pubkey::Pubkey};
 use solana_vote_program::vote_state::VoteState;
 
+use crate::identity_info::{IdentityInfoMap, ValidatorInfo};
 use crate::{
     banks_with_commitments::BanksWithCommitments,
     utils::{write_metric, Metric, MetricFamily},
     Lamports,
 };
 use std::{collections::HashSet, io, sync::Arc};
-use crate::identity_info::{IdentityInfoMap, ValidatorInfo};
 
 struct ValidatorVoteInfo {
     balance: Lamports,
@@ -20,7 +20,11 @@ struct ValidatorVoteInfo {
     validator_info: Option<ValidatorInfo>,
 }
 
-fn get_vote_state(bank: &Bank, vote_pubkey: &Pubkey, identity_info: &Arc<IdentityInfoMap>) -> Option<ValidatorVoteInfo> {
+fn get_vote_state(
+    bank: &Bank,
+    vote_pubkey: &Pubkey,
+    identity_info: &Arc<IdentityInfoMap>,
+) -> Option<ValidatorVoteInfo> {
     let default_vote_state = VoteState::default();
     let vote_accounts = bank.vote_accounts();
     let (activated_stake, vote_account) = vote_accounts.get(vote_pubkey)?;

--- a/prometheus/src/identity_info.rs
+++ b/prometheus/src/identity_info.rs
@@ -1,0 +1,117 @@
+use solana_config_program::ConfigKeys;
+use solana_sdk::pubkey::Pubkey;
+use solana_vote_program::vote_state::VoteState;
+
+use bincode;
+use serde::Deserialize;
+use serde_json;
+use solana_runtime::accounts_index::ScanConfig;
+use solana_sdk::account::ReadableAccount;
+use std::collections::HashMap;
+use std::{collections::HashSet, sync::Arc};
+use std::sync::RwLock;
+use solana_runtime::bank_forks::BankForks;
+use solana_sdk::transaction_context::TransactionAccount;
+
+/// ValidatorInfo represents selected fields from the config account data.
+#[derive(Debug, Default, Deserialize, Clone, Eq, PartialEq)]
+pub struct ValidatorInfo {
+    pub name: String,
+}
+
+pub type IdentityInfoMap = HashMap<Pubkey, ValidatorInfo>;
+
+pub fn map_vote_identity_to_info(bank_forks: &Arc<RwLock<BankForks>>, vote_pubkeys: &Arc<HashSet<Pubkey>>) -> IdentityInfoMap {
+    use solana_sdk::config::program as config_program;
+
+    let bank = bank_forks.read().unwrap().working_bank();
+
+    let all_accounts = bank
+        .get_program_accounts(&config_program::id(), &ScanConfig::default())
+        .expect("failed to get program accounts");
+
+    let default_vote_state = VoteState::default();
+    let vote_accounts = bank.vote_accounts();
+
+    let identities: HashSet<Pubkey> = vote_pubkeys.iter().filter_map(|vote_pubkey| {
+        let (_, vote_account) = vote_accounts.get(vote_pubkey)?;
+        let vote_state = vote_account.vote_state();
+        let vote_state = vote_state.as_ref().unwrap_or(&default_vote_state);
+
+        Some(vote_state.node_pubkey)
+    }).collect();
+
+    get_identity_validator_info(&all_accounts, &identities)
+}
+
+
+/// Return a map from validator identity account to ValidatorInfo.
+///
+/// To get the validator info (the validator metadata, such as name and Keybase
+/// username), we have to extract that from the config account that stores the
+/// validator info for a particular validator. But there is no way a priori to
+/// know the address of the config account for a given validator; the only way
+/// is to enumerate all config accounts and then find the one you are looking
+/// for. This function builds a map from identity account to validator info.
+fn get_identity_validator_info(all_accounts: &[TransactionAccount], identities: &HashSet<Pubkey>) -> HashMap<Pubkey, ValidatorInfo> {
+    let mut mapping = HashMap::new();
+
+    // Due to the structure of validator info (config accounts pointing to identity
+    // accounts), it is possible for multiple config accounts to describe the same
+    // validator. This is invalid, if it happens, we wouldn't know which config
+    // account is the right one, so instead of making an arbitrary decision, we
+    // ignore all validator infos for that identity.
+    let mut bad_identities = HashSet::new();
+
+    for (_, account) in all_accounts {
+        if let Some((validator_identity, validator_info)) = deserialize_validator_info(account.data()) {
+            // Skip identities we do not care about.
+            if !identities.contains(&validator_identity) {
+                continue;
+            }
+
+            let old_config_addr = mapping.insert(validator_identity, validator_info);
+            if old_config_addr.is_some() {
+                bad_identities.insert(validator_identity);
+            }
+        }
+    }
+
+    for bad_identity in &bad_identities {
+        mapping.remove(bad_identity);
+    }
+
+    mapping
+}
+
+/// Deserialize a config account that contains validator info.
+///
+/// Returns the validator identity account address, and the validator info for
+/// that validator.
+pub fn deserialize_validator_info(account_data: &[u8]) -> Option<(Pubkey, ValidatorInfo)> {
+    use solana_account_decoder::validator_info;
+
+    let key_list: ConfigKeys = bincode::deserialize(account_data).ok()?;
+
+    if !key_list.keys.contains(&(validator_info::id(), false)) {
+        return None;
+    }
+
+    // The validator identity pubkey lives at index 1.
+    let (validator_identity, identity_signed_config) = key_list.keys[1];
+    if !identity_signed_config {
+        return None;
+    }
+
+    // A config account stores a list of (pubkey, bool) pairs, followed by json
+    // data. To figure out where the json data starts, we need to know the size
+    // fo the key list. The json data is not stored directly, it is serialized
+    // with bincode as a string.
+    let key_list_len = bincode::serialized_size(&key_list)
+        .expect("We deserialized it, therefore it must be serializable.")
+        as usize;
+    let json_data: String = bincode::deserialize(&account_data[key_list_len..]).ok()?;
+    let validator_info: ValidatorInfo = serde_json::from_str(&json_data).ok()?;
+
+    Some((validator_identity, validator_info))
+}

--- a/prometheus/src/lib.rs
+++ b/prometheus/src/lib.rs
@@ -2,11 +2,13 @@ mod bank_metrics;
 pub mod banks_with_commitments;
 mod cluster_metrics;
 mod utils;
+pub mod identity_info;
 
 use banks_with_commitments::BanksWithCommitments;
 use solana_gossip::cluster_info::ClusterInfo;
 use solana_sdk::pubkey::Pubkey;
 use std::{collections::HashSet, sync::Arc};
+use identity_info::IdentityInfoMap;
 
 #[derive(Clone, Copy)]
 pub struct Lamports(pub u64);
@@ -15,6 +17,7 @@ pub fn render_prometheus(
     banks_with_commitments: BanksWithCommitments,
     cluster_info: &Arc<ClusterInfo>,
     vote_accounts: &Arc<HashSet<Pubkey>>,
+    identity_config: &Arc<IdentityInfoMap>,
 ) -> Vec<u8> {
     // There are 3 levels of commitment for a bank:
     // - finalized: most recent block *confirmed* by supermajority of the
@@ -28,6 +31,7 @@ pub fn render_prometheus(
         &banks_with_commitments,
         &cluster_info,
         vote_accounts,
+        identity_config,
         &mut out,
     )
     .expect("IO error");

--- a/prometheus/src/lib.rs
+++ b/prometheus/src/lib.rs
@@ -1,14 +1,14 @@
 mod bank_metrics;
 pub mod banks_with_commitments;
 mod cluster_metrics;
-mod utils;
 pub mod identity_info;
+mod utils;
 
 use banks_with_commitments::BanksWithCommitments;
+use identity_info::IdentityInfoMap;
 use solana_gossip::cluster_info::ClusterInfo;
 use solana_sdk::pubkey::Pubkey;
 use std::{collections::HashSet, sync::Arc};
-use identity_info::IdentityInfoMap;
 
 #[derive(Clone, Copy)]
 pub struct Lamports(pub u64);

--- a/prometheus/src/utils.rs
+++ b/prometheus/src/utils.rs
@@ -84,7 +84,11 @@ impl<'a> Metric<'a> {
         self
     }
 
-    pub fn with_optional_label(self, label_key: &'a str, label_value: Option<String>) -> Metric<'a> {
+    pub fn with_optional_label(
+        self,
+        label_key: &'a str,
+        label_value: Option<String>,
+    ) -> Metric<'a> {
         if let Some(label_value) = label_value {
             return self.with_label(label_key, label_value);
         }

--- a/prometheus/src/utils.rs
+++ b/prometheus/src/utils.rs
@@ -83,6 +83,13 @@ impl<'a> Metric<'a> {
         self.labels.push((label_key, label_value));
         self
     }
+
+    pub fn with_optional_label(self, label_key: &'a str, label_value: Option<String>) -> Metric<'a> {
+        if let Some(label_value) = label_value {
+            return self.with_label(label_key, label_value);
+        }
+        self
+    }
 }
 
 pub fn write_metric<W: Write>(out: &mut W, family: &MetricFamily) -> io::Result<()> {

--- a/prometheus/src/utils.rs
+++ b/prometheus/src/utils.rs
@@ -89,10 +89,10 @@ impl<'a> Metric<'a> {
         label_key: &'a str,
         label_value: Option<String>,
     ) -> Metric<'a> {
-        if let Some(label_value) = label_value {
-            return self.with_label(label_key, label_value);
+        match label_value {
+            Some(value) => self.with_label(label_key, value),
+            None => self,
         }
-        self
     }
 }
 

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -28,7 +28,7 @@ use {
     solana_metrics::inc_new_counter_info,
     solana_perf::thread::renice_this_thread,
     solana_poh::poh_recorder::PohRecorder,
-    solana_prometheus::{banks_with_commitments::BanksWithCommitments, render_prometheus},
+    solana_prometheus::{banks_with_commitments::BanksWithCommitments, render_prometheus, identity_info::IdentityInfoMap},
     solana_runtime::{
         bank_forks::BankForks, commitment::BlockCommitmentCache,
         snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_config::SnapshotConfig,
@@ -52,6 +52,7 @@ use {
     },
     tokio_util::codec::{BytesCodec, FramedRead},
 };
+use solana_prometheus::identity_info::map_vote_identity_to_info;
 
 const FULL_SNAPSHOT_REQUEST_PATH: &str = "/snapshot.tar.bz2";
 const INCREMENTAL_SNAPSHOT_REQUEST_PATH: &str = "/incremental-snapshot.tar.bz2";
@@ -75,6 +76,9 @@ struct RpcRequestMiddleware {
     health: Arc<RpcHealth>,
     block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
     vote_accounts_to_monitor: Arc<HashSet<Pubkey>>,
+    /// Initialized based on vote_accounts_to_monitor, maps identity
+    /// pubkey associated with the vote account to the validator info.
+    identity_info_map: Arc<IdentityInfoMap>,
 }
 
 impl RpcRequestMiddleware {
@@ -97,6 +101,7 @@ impl RpcRequestMiddleware {
             )
             .unwrap(),
             snapshot_config,
+            identity_info_map: Arc::new(map_vote_identity_to_info(&bank_forks, &vote_accounts_to_monitor)),
             bank_forks,
             health,
             block_commitment_cache,
@@ -306,6 +311,7 @@ impl RequestMiddleware for RpcRequestMiddleware {
                             banks_with_commitment,
                             &self.health.cluster_info,
                             &self.vote_accounts_to_monitor,
+                            &self.identity_info_map,
                         )))
                         .unwrap()
                         .into()


### PR DESCRIPTION
#### Summary of Changes

Get `validator_info` for validator identity and add `validator_name` label to metrics. This happens on startup so there is a small possibility that validators will change their names and label will be invalid. This should be fine given that it is not critical data and we restart / update validator every (couple) of weeks.

The label will be skipped if validator does not specify any info.
