### PR TITLE
Expose latest full and incremental snapshots metrics

### DIFF
--- a/prometheus/src/lib.rs
+++ b/prometheus/src/lib.rs
@@ -38,6 +38,8 @@ pub fn render_prometheus(
         &mut out,
     )
     .expect("IO error");
-    snapshot_metrics::write_snapshot_metrics(snapshot_config, &mut out).expect("IO error");
+    if let Some(snapshot_config) = snapshot_config {
+        snapshot_metrics::write_snapshot_metrics(snapshot_config, &mut out).expect("IO error");
+    }
     out
 }

--- a/prometheus/src/lib.rs
+++ b/prometheus/src/lib.rs
@@ -2,11 +2,13 @@ mod bank_metrics;
 pub mod banks_with_commitments;
 mod cluster_metrics;
 pub mod identity_info;
+mod snapshot_metrics;
 mod utils;
 
 use banks_with_commitments::BanksWithCommitments;
 use identity_info::IdentityInfoMap;
 use solana_gossip::cluster_info::ClusterInfo;
+use solana_runtime::snapshot_config::SnapshotConfig;
 use solana_sdk::pubkey::Pubkey;
 use std::{collections::HashSet, sync::Arc};
 
@@ -18,6 +20,7 @@ pub fn render_prometheus(
     cluster_info: &Arc<ClusterInfo>,
     vote_accounts: &Arc<HashSet<Pubkey>>,
     identity_config: &Arc<IdentityInfoMap>,
+    snapshot_config: &Option<SnapshotConfig>,
 ) -> Vec<u8> {
     // There are 3 levels of commitment for a bank:
     // - finalized: most recent block *confirmed* by supermajority of the
@@ -35,5 +38,6 @@ pub fn render_prometheus(
         &mut out,
     )
     .expect("IO error");
+    snapshot_metrics::write_snapshot_metrics(snapshot_config, &mut out).expect("IO error");
     out
 }

--- a/prometheus/src/snapshot_metrics.rs
+++ b/prometheus/src/snapshot_metrics.rs
@@ -1,0 +1,65 @@
+use crate::utils::{write_metric, Metric, MetricFamily};
+use solana_runtime::snapshot_archive_info::{SnapshotArchiveInfo, SnapshotArchiveInfoGetter};
+use solana_runtime::snapshot_config::SnapshotConfig;
+use solana_runtime::snapshot_utils;
+use solana_sdk::clock::Slot;
+use std::io;
+
+pub fn write_snapshot_metrics<W: io::Write>(
+    snapshot_config: &Option<SnapshotConfig>,
+    out: &mut W,
+) -> io::Result<()> {
+    let snapshot_config = match snapshot_config.as_ref() {
+        Some(config) => config,
+        None => return Ok(()),
+    };
+
+    let full_snapshot_info = match get_full_snapshot_info(snapshot_config) {
+        Some(info) => info,
+        None => return Ok(()),
+    };
+    write_metric(
+        out,
+        &MetricFamily {
+            name: "solana_full_snapshot_info",
+            help: "The slot height of the most recent full snapshot",
+            type_: "counter",
+            metrics: vec![Metric::new(full_snapshot_info.slot)
+                .with_label("hash", full_snapshot_info.hash.to_string())],
+        },
+    )?;
+
+    // Incremental snapshots may be disabled, so we write full snapshot
+    // metric before and just return early if that is the case.
+    let incremental_snapshot_info =
+        match get_incremental_snapshot_info(snapshot_config, full_snapshot_info.slot) {
+            None => return Ok(()),
+            Some(info) => info,
+        };
+    write_metric(
+        out,
+        &MetricFamily {
+            name: "solana_incremental_snapshot_info",
+            help: "The slot height of the most recent incremental snapshot",
+            type_: "counter",
+            metrics: vec![Metric::new(incremental_snapshot_info.slot)
+                .with_label("hash", incremental_snapshot_info.hash.to_string())],
+        },
+    )
+}
+
+fn get_full_snapshot_info(snapshot_config: &SnapshotConfig) -> Option<SnapshotArchiveInfo> {
+    snapshot_utils::get_highest_full_snapshot_archive_info(&snapshot_config.snapshot_archives_dir)
+        .map(|full_snapshot_info| full_snapshot_info.snapshot_archive_info().clone())
+}
+
+fn get_incremental_snapshot_info(
+    snapshot_config: &SnapshotConfig,
+    slot: Slot,
+) -> Option<SnapshotArchiveInfo> {
+    snapshot_utils::get_highest_incremental_snapshot_archive_info(
+        &snapshot_config.snapshot_archives_dir,
+        slot,
+    )
+    .map(|inc_snapshot_info| inc_snapshot_info.snapshot_archive_info().clone())
+}

--- a/prometheus/src/snapshot_metrics.rs
+++ b/prometheus/src/snapshot_metrics.rs
@@ -6,24 +6,23 @@ use solana_sdk::clock::Slot;
 use std::io;
 
 pub fn write_snapshot_metrics<W: io::Write>(
-    snapshot_config: &Option<SnapshotConfig>,
+    snapshot_config: &SnapshotConfig,
     out: &mut W,
 ) -> io::Result<()> {
-    let snapshot_config = match snapshot_config.as_ref() {
-        Some(config) => config,
-        None => return Ok(()),
-    };
-
-    let full_snapshot_info = match get_full_snapshot_info(snapshot_config) {
+    let full_snapshot_info = match snapshot_utils::get_highest_full_snapshot_archive_info(
+        &snapshot_config.snapshot_archives_dir,
+    )
+    .map(|full_snapshot_info| full_snapshot_info.snapshot_archive_info())
+    {
         Some(info) => info,
         None => return Ok(()),
     };
     write_metric(
         out,
         &MetricFamily {
-            name: "solana_full_snapshot_info",
+            name: "solana_snapshot_last_full_snapshot_slot",
             help: "The slot height of the most recent full snapshot",
-            type_: "counter",
+            type_: "gauge",
             metrics: vec![Metric::new(full_snapshot_info.slot)
                 .with_label("hash", full_snapshot_info.hash.to_string())],
         },
@@ -32,34 +31,23 @@ pub fn write_snapshot_metrics<W: io::Write>(
     // Incremental snapshots may be disabled, so we write full snapshot
     // metric before and just return early if that is the case.
     let incremental_snapshot_info =
-        match get_incremental_snapshot_info(snapshot_config, full_snapshot_info.slot) {
+        match snapshot_utils::get_highest_incremental_snapshot_archive_info(
+            &snapshot_config.snapshot_archives_dir,
+            slot,
+        )
+        .map(|inc_snapshot_info| inc_snapshot_info.snapshot_archive_info())
+        {
             None => return Ok(()),
             Some(info) => info,
         };
     write_metric(
         out,
         &MetricFamily {
-            name: "solana_incremental_snapshot_info",
+            name: "solana_snapshot_last_incremental_snapshot_slot",
             help: "The slot height of the most recent incremental snapshot",
-            type_: "counter",
+            type_: "gauge",
             metrics: vec![Metric::new(incremental_snapshot_info.slot)
                 .with_label("hash", incremental_snapshot_info.hash.to_string())],
         },
     )
-}
-
-fn get_full_snapshot_info(snapshot_config: &SnapshotConfig) -> Option<SnapshotArchiveInfo> {
-    snapshot_utils::get_highest_full_snapshot_archive_info(&snapshot_config.snapshot_archives_dir)
-        .map(|full_snapshot_info| full_snapshot_info.snapshot_archive_info().clone())
-}
-
-fn get_incremental_snapshot_info(
-    snapshot_config: &SnapshotConfig,
-    slot: Slot,
-) -> Option<SnapshotArchiveInfo> {
-    snapshot_utils::get_highest_incremental_snapshot_archive_info(
-        &snapshot_config.snapshot_archives_dir,
-        slot,
-    )
-    .map(|inc_snapshot_info| inc_snapshot_info.snapshot_archive_info().clone())
 }

--- a/prometheus/src/snapshot_metrics.rs
+++ b/prometheus/src/snapshot_metrics.rs
@@ -23,8 +23,7 @@ pub fn write_snapshot_metrics<W: io::Write>(
             name: "solana_snapshot_last_full_snapshot_slot",
             help: "The slot height of the most recent full snapshot",
             type_: "gauge",
-            metrics: vec![Metric::new(full_snapshot_info.slot)
-                .with_label("hash", full_snapshot_info.hash.to_string())],
+            metrics: vec![Metric::new(full_snapshot_info.slot)],
         },
     )?;
 
@@ -46,8 +45,7 @@ pub fn write_snapshot_metrics<W: io::Write>(
             name: "solana_snapshot_last_incremental_snapshot_slot",
             help: "The slot height of the most recent incremental snapshot",
             type_: "gauge",
-            metrics: vec![Metric::new(incremental_snapshot_info.slot)
-                .with_label("hash", incremental_snapshot_info.hash.to_string())],
+            metrics: vec![Metric::new(incremental_snapshot_info.slot)],
         },
     )
 }

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -1,5 +1,6 @@
 //! The `rpc_service` module implements the Solana JSON RPC service.
 
+use solana_prometheus::identity_info::map_vote_identity_to_info;
 use {
     crate::{
         cluster_tpu_info::ClusterTpuInfo,
@@ -28,7 +29,10 @@ use {
     solana_metrics::inc_new_counter_info,
     solana_perf::thread::renice_this_thread,
     solana_poh::poh_recorder::PohRecorder,
-    solana_prometheus::{banks_with_commitments::BanksWithCommitments, render_prometheus, identity_info::IdentityInfoMap},
+    solana_prometheus::{
+        banks_with_commitments::BanksWithCommitments, identity_info::IdentityInfoMap,
+        render_prometheus,
+    },
     solana_runtime::{
         bank_forks::BankForks, commitment::BlockCommitmentCache,
         snapshot_archive_info::SnapshotArchiveInfoGetter, snapshot_config::SnapshotConfig,
@@ -52,7 +56,6 @@ use {
     },
     tokio_util::codec::{BytesCodec, FramedRead},
 };
-use solana_prometheus::identity_info::map_vote_identity_to_info;
 
 const FULL_SNAPSHOT_REQUEST_PATH: &str = "/snapshot.tar.bz2";
 const INCREMENTAL_SNAPSHOT_REQUEST_PATH: &str = "/incremental-snapshot.tar.bz2";
@@ -101,7 +104,10 @@ impl RpcRequestMiddleware {
             )
             .unwrap(),
             snapshot_config,
-            identity_info_map: Arc::new(map_vote_identity_to_info(&bank_forks, &vote_accounts_to_monitor)),
+            identity_info_map: Arc::new(map_vote_identity_to_info(
+                &bank_forks,
+                &vote_accounts_to_monitor,
+            )),
             bank_forks,
             health,
             block_commitment_cache,
@@ -312,6 +318,7 @@ impl RequestMiddleware for RpcRequestMiddleware {
                             &self.health.cluster_info,
                             &self.vote_accounts_to_monitor,
                             &self.identity_info_map,
+                            &self.snapshot_config,
                         )))
                         .unwrap()
                         .into()


### PR DESCRIPTION
Expose metrics about slot height of the latest full and incremental snapshots.

Example from querying `/metrics`:
```
# HELP solana_full_snapshot_info The slot height of the most recent full snapshot
# TYPE solana_full_snapshot_info counter
solana_full_snapshot_info{hash="DEqtnEahjh6f7v6oAkmfhJZ6CJGdnikjYCyeYcbEFRE6"} 7440

# HELP solana_incremental_snapshot_info The slot height of the most recent incremental snapshot
# TYPE solana_incremental_snapshot_info counter
solana_incremental_snapshot_info{hash="2ZogpKCE7RSZ2NoJHATk6xzD4jLbrMcQTxtSt1uELYby"} 7841
```
