### PR TITLE
Add flag to enable prometheus metrics

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -687,6 +687,7 @@ impl Validator {
         };
 
         let rpc_override_health_check = Arc::new(AtomicBool::new(false));
+        let rpc_enable_prometheus_metrics = config.rpc_config.rpc_enable_prometheus_metrics;
         let (
             json_rpc_service,
             pubsub_service,
@@ -734,6 +735,7 @@ impl Validator {
                     config.validator_exit.clone(),
                     config.known_validators.clone(),
                     rpc_override_health_check.clone(),
+                    rpc_enable_prometheus_metrics,
                     optimistically_confirmed_bank.clone(),
                     config.send_transaction_service_config.clone(),
                     max_slots.clone(),

--- a/prometheus/src/utils.rs
+++ b/prometheus/src/utils.rs
@@ -94,6 +94,11 @@ impl<'a> Metric<'a> {
             None => self,
         }
     }
+
+    pub fn with_suffix(mut self, suffix: &'a str) -> Metric<'a> {
+        self.suffix = suffix;
+        self
+    }
 }
 
 pub fn write_metric<W: Write>(out: &mut W, family: &MetricFamily) -> io::Result<()> {

--- a/replica-node/src/main.rs
+++ b/replica-node/src/main.rs
@@ -167,6 +167,12 @@ pub fn main() {
                 .help("Require the shred version be this value"),
         )
         .arg(
+            Arg::with_name("enable_prometheus_metrics")
+                .long("enable-prometheus-metrics")
+                .takes_value(false)
+                .help("Expose prometheus on RPC endpoint /metrics")
+        )
+        .arg(
             Arg::with_name("logfile")
                 .short("o")
                 .long("log")
@@ -278,6 +284,8 @@ pub fn main() {
     let dynamic_port_range =
         solana_net_utils::parse_port_range(matches.value_of("dynamic_port_range").unwrap())
             .expect("invalid dynamic_port_range");
+
+    let rpc_enable_prometheus_metrics = matches.is_present("enable_prometheus_metrics");
 
     let cluster_entrypoints = entrypoint_addrs
         .iter()
@@ -402,6 +410,7 @@ pub fn main() {
         accounts_db_caching_enabled: false,
         replica_exit: Arc::new(RwLock::new(Exit::default())),
         vote_accounts_to_monitor: Arc::new(HashSet::default()),
+        rpc_enable_prometheus_metrics,
     };
 
     let replica = ReplicaNode::new(config);

--- a/replica-node/src/replica_node.rs
+++ b/replica-node/src/replica_node.rs
@@ -63,6 +63,7 @@ pub struct ReplicaNodeConfig {
     pub replica_exit: Arc<RwLock<Exit>>,
     pub socket_addr_space: SocketAddrSpace,
     pub vote_accounts_to_monitor: Arc<HashSet<Pubkey>>,
+    pub rpc_enable_prometheus_metrics: bool,
 }
 
 pub struct ReplicaNode {
@@ -206,6 +207,7 @@ fn start_client_rpc_services(
     ));
 
     let rpc_override_health_check = Arc::new(AtomicBool::new(false));
+    let rpc_enable_prometheus_metrics = replica_config.rpc_enable_prometheus_metrics;
     if ContactInfo::is_valid_address(&replica_config.rpc_addr, socket_addr_space) {
         assert!(ContactInfo::is_valid_address(
             &replica_config.rpc_pubsub_addr,
@@ -246,6 +248,7 @@ fn start_client_rpc_services(
             replica_config.replica_exit.clone(),
             None,
             rpc_override_health_check,
+            rpc_enable_prometheus_metrics,
             optimistically_confirmed_bank.clone(),
             send_transaction_service::Config {
                 retry_rate_ms: 0,

--- a/replica-node/tests/local_replica.rs
+++ b/replica-node/tests/local_replica.rs
@@ -30,6 +30,7 @@ use {
     },
     solana_streamer::socket::SocketAddrSpace,
     std::{
+        collections::HashSet,
         net::{IpAddr, Ipv4Addr, SocketAddr},
         path::{Path, PathBuf},
         sync::{Arc, RwLock},
@@ -294,6 +295,8 @@ fn test_replica_bootstrap() {
         account_indexes: AccountSecondaryIndexes::default(),
         accounts_db_caching_enabled: false,
         replica_exit: Arc::new(RwLock::new(Exit::default())),
+        vote_accounts_to_monitor: Arc::new(HashSet::default()),
+        rpc_enable_prometheus_metrics: false,
     };
     let _replica_node = ReplicaNode::new(config);
 }

--- a/rpc/src/rpc.rs
+++ b/rpc/src/rpc.rs
@@ -158,6 +158,7 @@ pub struct JsonRpcConfig {
     pub rpc_niceness_adj: i8,
     pub full_api: bool,
     pub obsolete_v1_7_api: bool,
+    pub rpc_enable_prometheus_metrics: bool,
     pub rpc_scan_and_fix_roots: bool,
 }
 

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -79,6 +79,7 @@ struct RpcRequestMiddleware {
     health: Arc<RpcHealth>,
     block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
     vote_accounts_to_monitor: Arc<HashSet<Pubkey>>,
+    enable_prometheus_metrics: bool,
     /// Initialized based on vote_accounts_to_monitor, maps identity
     /// pubkey associated with the vote account to the validator info.
     identity_info_map: Arc<IdentityInfoMap>,
@@ -92,6 +93,7 @@ impl RpcRequestMiddleware {
         health: Arc<RpcHealth>,
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
         vote_accounts_to_monitor: Arc<HashSet<Pubkey>>,
+        enable_prometheus_metrics: bool,
     ) -> Self {
         Self {
             ledger_path,
@@ -112,6 +114,7 @@ impl RpcRequestMiddleware {
             health,
             block_commitment_cache,
             vote_accounts_to_monitor,
+            enable_prometheus_metrics,
         }
     }
 
@@ -307,7 +310,7 @@ impl RequestMiddleware for RpcRequestMiddleware {
                     .body(hyper::Body::from(self.health_check()))
                     .unwrap()
                     .into(),
-                "/metrics" => {
+                "/metrics" if self.enable_prometheus_metrics => {
                     let banks_with_commitment =
                         BanksWithCommitments::new(&self.bank_forks, &self.block_commitment_cache);
                     hyper::Response::builder()
@@ -368,6 +371,7 @@ impl JsonRpcService {
         validator_exit: Arc<RwLock<Exit>>,
         known_validators: Option<HashSet<Pubkey>>,
         override_health_check: Arc<AtomicBool>,
+        enable_prometheus_metrics: bool,
         optimistically_confirmed_bank: Arc<RwLock<OptimisticallyConfirmedBank>>,
         send_transaction_service_config: send_transaction_service::Config,
         max_slots: Arc<MaxSlots>,
@@ -524,6 +528,7 @@ impl JsonRpcService {
                     health.clone(),
                     block_commitment_cache.clone(),
                     vote_accounts_to_monitor,
+                    enable_prometheus_metrics,
                 );
                 let server = ServerBuilder::with_meta_extractor(
                     io,
@@ -651,6 +656,7 @@ mod tests {
             validator_exit,
             None,
             Arc::new(AtomicBool::new(false)),
+            false,
             optimistically_confirmed_bank,
             send_transaction_service::Config {
                 retry_rate_ms: 1000,
@@ -709,6 +715,7 @@ mod tests {
             RpcHealth::stub(),
             block_commitment_cache,
             None,
+            false,
         );
         let rrm_with_snapshot_config = RpcRequestMiddleware::new(
             PathBuf::from("/"),
@@ -717,6 +724,7 @@ mod tests {
             RpcHealth::stub(),
             block_commitment_cache,
             None,
+            false,
         );
 
         assert!(rrm.is_file_get_path(DEFAULT_GENESIS_DOWNLOAD_PATH));
@@ -789,6 +797,7 @@ mod tests {
             RpcHealth::stub(),
             Arc::new(RwLock::new(BlockCommitmentCache::default())),
             None,
+            false,
         );
 
         // File does not exist => request should fail.
@@ -846,6 +855,7 @@ mod tests {
             RpcHealth::stub(),
             Arc::new(RwLock::new(BlockCommitmentCache::default())),
             None,
+            false,
         );
         assert_eq!(rm.health_check(), "ok");
     }
@@ -879,6 +889,7 @@ mod tests {
             health,
             Arc::new(RwLock::new(BlockCommitmentCache::default())),
             None,
+            false,
         );
 
         // No account hashes for this node or any known validators

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -667,7 +667,7 @@ mod tests {
             Arc::new(LeaderScheduleCache::default()),
             connection_cache,
             Arc::new(AtomicU64::default()),
-            None,
+            Arc::new(HashSet::default()),
         );
         let thread = rpc_service.thread_hdl.thread();
         assert_eq!(thread.name().unwrap(), "solana-jsonrpc");
@@ -713,8 +713,8 @@ mod tests {
             None,
             bank_forks.clone(),
             RpcHealth::stub(),
-            block_commitment_cache,
-            None,
+            block_commitment_cache.clone(),
+            Arc::new(HashSet::default()),
             false,
         );
         let rrm_with_snapshot_config = RpcRequestMiddleware::new(
@@ -723,7 +723,7 @@ mod tests {
             bank_forks,
             RpcHealth::stub(),
             block_commitment_cache,
-            None,
+            Arc::new(HashSet::default()),
             false,
         );
 
@@ -796,7 +796,7 @@ mod tests {
             create_bank_forks(),
             RpcHealth::stub(),
             Arc::new(RwLock::new(BlockCommitmentCache::default())),
-            None,
+            Arc::new(HashSet::default()),
             false,
         );
 
@@ -854,7 +854,7 @@ mod tests {
             create_bank_forks(),
             RpcHealth::stub(),
             Arc::new(RwLock::new(BlockCommitmentCache::default())),
-            None,
+            Arc::new(HashSet::default()),
             false,
         );
         assert_eq!(rm.health_check(), "ok");
@@ -888,7 +888,7 @@ mod tests {
             create_bank_forks(),
             health,
             Arc::new(RwLock::new(BlockCommitmentCache::default())),
-            None,
+            Arc::new(HashSet::default()),
             false,
         );
 

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -1446,6 +1446,12 @@ pub fn main() {
                 .help("Verifies blockstore roots on boot and fixes any gaps"),
         )
         .arg(
+            Arg::with_name("enable_prometheus_metrics")
+                .long("enable-prometheus-metrics")
+                .takes_value(false)
+                .help("Expose prometheus on RPC endpoint /metrics")
+        )
+        .arg(
             Arg::with_name("enable_accountsdb_repl")
                 .long("enable-accountsdb-repl")
                 .takes_value(false)
@@ -2529,6 +2535,7 @@ pub fn main() {
             rpc_niceness_adj: value_t_or_exit!(matches, "rpc_niceness_adj", i8),
             account_indexes: account_indexes.clone(),
             rpc_scan_and_fix_roots: matches.is_present("rpc_scan_and_fix_roots"),
+            rpc_enable_prometheus_metrics: matches.is_present("enable_prometheus_metrics"),
         },
         accountsdb_repl_service_config,
         geyser_plugin_config_files,


### PR DESCRIPTION
#### Problem

Add flag to expose prometheus metrics.
The metrics shouldn't be exposed by default.

#### Summary of Changes

Add condition flag on `/metrics` endpoint

#### Possible improvements

- naming could be better
- add a way to specify the metrics endpoint e.g. 
   - convert the flag into an option`--rpc-prometheus-metrics "/metrics"`
   - or add another option `--rpc-prometheus-metrics --rpc-prometheus-metrics-endpoint "/metrics"`
   - **but** if we want to add a way to specify an endpoint, we have to deal with possible conflicts. So I would not add it.