### PR TITLE
Prometheus 1.18 startup time fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6780,6 +6780,7 @@ version = "1.10.28"
 dependencies = [
  "bincode",
  "jsonrpc-http-server",
+ "log",
  "serde",
  "serde_json",
  "solana-account-decoder",

--- a/prometheus/Cargo.toml
+++ b/prometheus/Cargo.toml
@@ -19,6 +19,7 @@ solana-config-program = { path = "../programs/config" }
 bincode = "1.3.3"
 solana-account-decoder = { path = "../account-decoder" }
 solana-accounts-db = { path = "../accounts-db" }
+log = { workspace = true }
 
 [lib]
 crate-type = ["lib"]

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -23,7 +23,7 @@ struct ValidatorVoteInfo {
 fn get_vote_state(
     bank: &Bank,
     vote_pubkey: &Pubkey,
-    identity_info: &Arc<IdentityInfoMap>,
+    identity_info: &IdentityInfoMap,
 ) -> Option<ValidatorVoteInfo> {
     let default_vote_state = VoteState::default();
     let vote_accounts = bank.vote_accounts();
@@ -48,11 +48,9 @@ fn get_vote_state(
     })
 }
 
-pub fn write_cluster_metrics<W: io::Write>(
+pub fn write_node_metrics<W: io::Write>(
     banks_with_commitments: &BanksWithCommitments,
     cluster_info: &Arc<ClusterInfo>,
-    vote_accounts: &Arc<HashSet<Pubkey>>,
-    identity_info: &Arc<IdentityInfoMap>,
     out: &mut W,
 ) -> io::Result<()> {
     let identity_pubkey = cluster_info.id();
@@ -97,6 +95,15 @@ pub fn write_cluster_metrics<W: io::Write>(
         },
     )?;
 
+    Ok(())
+}
+
+pub fn write_accounts_metrics<W: io::Write>(
+    banks_with_commitments: &BanksWithCommitments,
+    vote_accounts: &Arc<HashSet<Pubkey>>,
+    identity_info: &IdentityInfoMap,
+    out: &mut W,
+) -> io::Result<()> {
     // Vote accounts information
     for vote_account in vote_accounts.iter() {
         write_metric(

--- a/prometheus/src/identity_info.rs
+++ b/prometheus/src/identity_info.rs
@@ -12,6 +12,7 @@ use solana_sdk::transaction_context::TransactionAccount;
 use std::collections::HashMap;
 use std::sync::RwLock;
 use std::{collections::HashSet, sync::Arc};
+use log::info;
 
 /// ValidatorInfo represents selected fields from the config account data.
 #[derive(Debug, Default, Deserialize, Clone, Eq, PartialEq)]
@@ -27,15 +28,19 @@ pub fn map_vote_identity_to_info(
 ) -> IdentityInfoMap {
     use solana_sdk::config::program as config_program;
 
+    info!("map_vote_identity_to_info: reading bank...");
     let bank = bank_forks.read().unwrap().working_bank();
 
+    info!("map_vote_identity_to_info: starting to get all accounts...");
     let all_accounts = bank
         .get_program_accounts(&config_program::id(), &ScanConfig::default())
         .expect("failed to get program accounts");
 
+    info!("map_vote_identity_to_info: reading vote accounts...");
     let default_vote_state = VoteState::default();
     let vote_accounts = bank.vote_accounts();
 
+    info!("map_vote_identity_to_info: matching votes to identities...");
     let identities: HashSet<Pubkey> = vote_pubkeys
         .iter()
         .filter_map(|vote_pubkey| {
@@ -47,6 +52,7 @@ pub fn map_vote_identity_to_info(
         })
         .collect();
 
+    info!("map_vote_identity_to_info: getting validator info...");
     get_identity_validator_info(&all_accounts, &identities)
 }
 

--- a/prometheus/src/lib.rs
+++ b/prometheus/src/lib.rs
@@ -17,6 +17,7 @@ use std::{
     sync::{Arc, RwLock},
     thread,
 };
+use log::info;
 
 #[derive(Clone, Copy)]
 pub struct Lamports(pub u64);
@@ -55,8 +56,10 @@ impl PrometheusMetrics {
 
         let prom_metrics_clone = prom_metrics.clone();
         thread::spawn(move || {
+            info!("Initializing identity info map...");
             // TODO: This can panic, we should handle it better
             let identity_info_map = map_vote_identity_to_info(&bank_forks, &vote_accounts);
+            info!("Identity info map initialized. Enabling accounts metrics...");
             prom_metrics_clone
                 .identity_info_map
                 .write()

--- a/prometheus/src/lib.rs
+++ b/prometheus/src/lib.rs
@@ -6,40 +6,96 @@ mod snapshot_metrics;
 mod utils;
 
 use banks_with_commitments::BanksWithCommitments;
-use identity_info::IdentityInfoMap;
+use identity_info::{map_vote_identity_to_info, IdentityInfoMap};
 use solana_gossip::cluster_info::ClusterInfo;
-use solana_runtime::snapshot_config::SnapshotConfig;
+use solana_runtime::{
+    bank_forks::BankForks, commitment::BlockCommitmentCache, snapshot_config::SnapshotConfig,
+};
 use solana_sdk::pubkey::Pubkey;
-use std::{collections::HashSet, sync::Arc};
+use std::{
+    collections::HashSet,
+    sync::{Arc, RwLock},
+    thread,
+};
 
 #[derive(Clone, Copy)]
 pub struct Lamports(pub u64);
 
-pub fn render_prometheus(
-    banks_with_commitments: BanksWithCommitments,
-    cluster_info: &Arc<ClusterInfo>,
-    vote_accounts: &Arc<HashSet<Pubkey>>,
-    identity_config: &Arc<IdentityInfoMap>,
-    snapshot_config: &Option<SnapshotConfig>,
-) -> Vec<u8> {
-    // There are 3 levels of commitment for a bank:
-    // - finalized: most recent block *confirmed* by supermajority of the
-    // cluster.
-    // - confirmed: most recent block that has been *voted* on by supermajority
-    // of the cluster.
-    // - processed: most recent block.
-    let mut out: Vec<u8> = Vec::new();
-    bank_metrics::write_bank_metrics(&banks_with_commitments, &mut out).expect("IO error");
-    cluster_metrics::write_cluster_metrics(
-        &banks_with_commitments,
-        &cluster_info,
-        vote_accounts,
-        identity_config,
-        &mut out,
-    )
-    .expect("IO error");
-    if let Some(snapshot_config) = snapshot_config {
-        snapshot_metrics::write_snapshot_metrics(snapshot_config, &mut out).expect("IO error");
+pub struct PrometheusMetrics {
+    bank_forks: Arc<RwLock<BankForks>>,
+    block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
+    cluster_info: Arc<ClusterInfo>,
+    vote_accounts: Arc<HashSet<Pubkey>>,
+    snapshot_config: Option<SnapshotConfig>,
+    /// Initialized based on vote_accounts. Maps identity
+    /// pubkey associated with the vote account to the validator info.
+    /// Since loading accounts takes a lot of time, we initialize it in a
+    /// separate thread, hence the RwLock - to set the data later from a
+    /// different thread.
+    identity_info_map: RwLock<Option<IdentityInfoMap>>,
+}
+
+impl PrometheusMetrics {
+    pub fn new(
+        bank_forks: Arc<RwLock<BankForks>>,
+        block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
+        cluster_info: Arc<ClusterInfo>,
+        vote_accounts: Arc<HashSet<Pubkey>>,
+        snapshot_config: Option<SnapshotConfig>,
+    ) -> Arc<Self> {
+        let prom_metrics = Self {
+            bank_forks: bank_forks.clone(),
+            block_commitment_cache,
+            cluster_info,
+            vote_accounts: vote_accounts.clone(),
+            identity_info_map: RwLock::new(None),
+            snapshot_config,
+        };
+        let prom_metrics = Arc::new(prom_metrics);
+
+        let prom_metrics_clone = prom_metrics.clone();
+        thread::spawn(move || {
+            // TODO: This can panic, we should handle it better
+            let identity_info_map = map_vote_identity_to_info(&bank_forks, &vote_accounts);
+            prom_metrics_clone
+                .identity_info_map
+                .write()
+                .unwrap()
+                .replace(identity_info_map);
+        });
+
+        prom_metrics
     }
-    out
+
+    pub fn render_prometheus(&self) -> Vec<u8> {
+        let banks_with_comm =
+            BanksWithCommitments::new(&self.bank_forks, &self.block_commitment_cache);
+
+        // There are 3 levels of commitment for a bank:
+        // - finalized: most recent block *confirmed* by supermajority of the
+        // cluster.
+        // - confirmed: most recent block that has been *voted* on by supermajority
+        // of the cluster.
+        // - processed: most recent block.
+        let mut out: Vec<u8> = Vec::new();
+        bank_metrics::write_bank_metrics(&banks_with_comm, &mut out).expect("IO error");
+
+        cluster_metrics::write_node_metrics(&banks_with_comm, &self.cluster_info, &mut out)
+            .expect("IO error");
+
+        let identity_map = &self.identity_info_map.read().unwrap().clone();
+        if let Some(identity_info_map) = identity_map {
+            cluster_metrics::write_accounts_metrics(
+                &banks_with_comm,
+                &self.vote_accounts,
+                identity_info_map,
+                &mut out,
+            )
+            .expect("IO error");
+        }
+        if let Some(snapshot_config) = self.snapshot_config.as_ref() {
+            snapshot_metrics::write_snapshot_metrics(snapshot_config, &mut out).expect("IO error");
+        }
+        out
+    }
 }


### PR DESCRIPTION
#### Summary of Changes

Initialize `identity_info_map` in a separate thread exposing only base metrics initially to avoid loading accounts on startup.

I still need to test it.