### PR TITLE
Add support for monitoring arbitrary accounts balances

### DIFF
--- a/core/src/validator.rs
+++ b/core/src/validator.rs
@@ -224,6 +224,7 @@ pub struct ValidatorConfig {
     pub repair_whitelist: Arc<RwLock<HashSet<Pubkey>>>, // Empty = repair with all
     pub gossip_validators: Option<HashSet<Pubkey>>, // None = gossip with all
     pub vote_accounts_to_monitor: Arc<HashSet<Pubkey>>,
+    pub accounts_to_monitor_balance: Arc<HashSet<Pubkey>>,
     pub accounts_hash_fault_injector: Option<AccountsHashFaultInjector>,
     pub accounts_hash_interval_slots: u64,
     pub max_genesis_archive_unpacked_size: u64,
@@ -296,6 +297,7 @@ impl Default for ValidatorConfig {
             repair_whitelist: Arc::new(RwLock::new(HashSet::default())),
             gossip_validators: None,
             vote_accounts_to_monitor: Arc::new(HashSet::new()),
+            accounts_to_monitor_balance: Arc::new(HashSet::new()),
             accounts_hash_fault_injector: None,
             accounts_hash_interval_slots: std::u64::MAX,
             max_genesis_archive_unpacked_size: MAX_GENESIS_ARCHIVE_UNPACKED_SIZE,
@@ -1013,6 +1015,7 @@ impl Validator {
                 max_complete_rewards_slot,
                 prioritization_fee_cache.clone(),
                 config.vote_accounts_to_monitor.clone(),
+                config.accounts_to_monitor_balance.clone(),
             )?;
 
             (

--- a/prometheus/src/cluster_metrics.rs
+++ b/prometheus/src/cluster_metrics.rs
@@ -101,6 +101,7 @@ pub fn write_node_metrics<W: io::Write>(
 pub fn write_accounts_metrics<W: io::Write>(
     banks_with_commitments: &BanksWithCommitments,
     vote_accounts: &Arc<HashSet<Pubkey>>,
+    accounts_to_monitor_balance: &Arc<HashSet<Pubkey>>,
     identity_info: &IdentityInfoMap,
     out: &mut W,
 ) -> io::Result<()> {
@@ -186,6 +187,23 @@ pub fn write_accounts_metrics<W: io::Write>(
                                 "validator_name",
                                 vote_info.validator_info.map(|v| v.name),
                             ),
+                    )
+                }),
+            },
+        )?;
+    }
+
+    for account_to_monitor_balance in accounts_to_monitor_balance.iter() {
+        write_metric(
+            out,
+            &MetricFamily {
+                name: "solana_account_balance_sol",
+                help: "The balance of the account at the given address",
+                type_: "gauge",
+                metrics: banks_with_commitments.for_each_commitment(|bank| {
+                    Some(
+                        Metric::new_sol(Lamports(bank.get_balance(account_to_monitor_balance)))
+                            .with_label("account", account_to_monitor_balance.to_string()),
                     )
                 }),
             },

--- a/prometheus/src/identity_info.rs
+++ b/prometheus/src/identity_info.rs
@@ -3,6 +3,7 @@ use solana_sdk::pubkey::Pubkey;
 use solana_vote_program::vote_state::VoteState;
 
 use bincode;
+use log::info;
 use serde::Deserialize;
 use serde_json;
 use solana_accounts_db::accounts_index::ScanConfig;
@@ -12,7 +13,6 @@ use solana_sdk::transaction_context::TransactionAccount;
 use std::collections::HashMap;
 use std::sync::RwLock;
 use std::{collections::HashSet, sync::Arc};
-use log::info;
 
 /// ValidatorInfo represents selected fields from the config account data.
 #[derive(Debug, Default, Deserialize, Clone, Eq, PartialEq)]

--- a/prometheus/src/lib.rs
+++ b/prometheus/src/lib.rs
@@ -7,6 +7,7 @@ mod utils;
 
 use banks_with_commitments::BanksWithCommitments;
 use identity_info::{map_vote_identity_to_info, IdentityInfoMap};
+use log::info;
 use solana_gossip::cluster_info::ClusterInfo;
 use solana_runtime::{
     bank_forks::BankForks, commitment::BlockCommitmentCache, snapshot_config::SnapshotConfig,
@@ -17,7 +18,6 @@ use std::{
     sync::{Arc, RwLock},
     thread,
 };
-use log::info;
 
 #[derive(Clone, Copy)]
 pub struct Lamports(pub u64);
@@ -27,6 +27,7 @@ pub struct PrometheusMetrics {
     block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
     cluster_info: Arc<ClusterInfo>,
     vote_accounts: Arc<HashSet<Pubkey>>,
+    accounts_to_monitor_balance: Arc<HashSet<Pubkey>>,
     snapshot_config: Option<SnapshotConfig>,
     /// Initialized based on vote_accounts. Maps identity
     /// pubkey associated with the vote account to the validator info.
@@ -42,6 +43,7 @@ impl PrometheusMetrics {
         block_commitment_cache: Arc<RwLock<BlockCommitmentCache>>,
         cluster_info: Arc<ClusterInfo>,
         vote_accounts: Arc<HashSet<Pubkey>>,
+        accounts_to_monitor_balance: Arc<HashSet<Pubkey>>,
         snapshot_config: Option<SnapshotConfig>,
     ) -> Arc<Self> {
         let prom_metrics = Self {
@@ -49,6 +51,7 @@ impl PrometheusMetrics {
             block_commitment_cache,
             cluster_info,
             vote_accounts: vote_accounts.clone(),
+            accounts_to_monitor_balance: accounts_to_monitor_balance.clone(),
             identity_info_map: RwLock::new(None),
             snapshot_config,
         };
@@ -91,6 +94,7 @@ impl PrometheusMetrics {
             cluster_metrics::write_accounts_metrics(
                 &banks_with_comm,
                 &self.vote_accounts,
+                &self.accounts_to_monitor_balance,
                 identity_info_map,
                 &mut out,
             )

--- a/rpc/src/rpc_service.rs
+++ b/rpc/src/rpc_service.rs
@@ -377,6 +377,7 @@ impl JsonRpcService {
         max_complete_rewards_slot: Arc<AtomicU64>,
         prioritization_fee_cache: Arc<PrioritizationFeeCache>,
         vote_accounts_to_monitor: Arc<HashSet<Pubkey>>,
+        accounts_to_monitor_balance: Arc<HashSet<Pubkey>>,
     ) -> Result<Self, String> {
         info!("rpc bound to {:?}", rpc_addr);
         info!("rpc configuration: {:?}", config);
@@ -540,6 +541,7 @@ impl JsonRpcService {
                         block_commitment_cache.clone(),
                         cluster_info.clone(),
                         vote_accounts_to_monitor.clone(),
+                        accounts_to_monitor_balance.clone(),
                         snapshot_config.clone(),
                     ))
                 } else {
@@ -686,6 +688,7 @@ mod tests {
             Arc::new(AtomicU64::default()),
             Arc::new(AtomicU64::default()),
             Arc::new(PrioritizationFeeCache::default()),
+            Arc::new(HashSet::default()),
             Arc::new(HashSet::default()),
         )
         .expect("assume successful JsonRpcService start");

--- a/validator/src/cli.rs
+++ b/validator/src/cli.rs
@@ -1768,6 +1768,15 @@ pub fn app<'a>(version: &'a str, default_args: &'a DefaultArgs) -> App<'a, 'a> {
                    The validator's own vote account is always included implicitly \
                    if there is one.")
         )
+        .arg(
+            Arg::with_name("monitor_account_balance")
+                .long("monitor-account-balance")
+                .takes_value(true)
+                .value_name("PUBKEY")
+                .validator(is_pubkey)
+                .multiple(true)
+                .help("Arbitrary accounts to expose Prometheus metrics about their balances.")
+        )
         // End Chorus changes
     ;
 }

--- a/validator/src/main.rs
+++ b/validator/src/main.rs
@@ -415,6 +415,16 @@ fn get_vote_accounts_to_monitor(matches: &ArgMatches<'_>) -> HashSet<Pubkey> {
     monitor_vote_accounts
 }
 
+fn get_accounts_to_monitor_balance(matches: &ArgMatches<'_>) -> HashSet<Pubkey> {
+    if matches.is_present("monitor_account_balance") {
+        values_t_or_exit!(matches, "monitor_account_balance", Pubkey)
+            .into_iter()
+            .collect()
+    } else {
+        HashSet::new()
+    }
+}
+
 fn validators_set(
     identity_pubkey: &Pubkey,
     matches: &ArgMatches<'_>,
@@ -1470,6 +1480,9 @@ pub fn main() {
     });
 
     validator_config.vote_accounts_to_monitor = Arc::new(get_vote_accounts_to_monitor(&matches));
+
+    validator_config.accounts_to_monitor_balance =
+        Arc::new(get_accounts_to_monitor_balance(&matches));
 
     let dynamic_port_range =
         solana_net_utils::parse_port_range(matches.value_of("dynamic_port_range").unwrap())


### PR DESCRIPTION
### Details
Add feature to expose Prometheus metrics about arbitrary account balances. The exposed metric is `solana_account_balance_sol` and the CLI argument to configure it is as follows:

```bash
        --monitor-account-balance <PUBKEY>...
            Arbitrary accounts to expose Prometheus metrics about their balances.

```

### Test Plan
* Compiles: :heavy_check_mark: 
* Functionality: _NOT tested yet!_
